### PR TITLE
Removes platform.js from code samples

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,7 +16,6 @@
 
 {% if site.load_platform %}
   <!-- Toolkit platform code -->
-  <script src="/toolkit/platform/platform.js?{{'now' | date: "%Y%m%d"}}"></script>
   <script src="/toolkit/toolkit.js?{{'now' | date: "%Y%m%d"}}"></script>
   <!-- TODO(ericbidelman): switch to toolkit.min.js when
        https://github.com/toolkitchen/toolkit/issues/91 is fixed

--- a/_includes/samples/tk-binding-to-elements.html
+++ b/_includes/samples/tk-binding-to-elements.html
@@ -19,7 +19,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="toolkit/platform/platform.js"></script>
     <script src="toolkit/toolkit.js"></script>
     <link rel="import" href="tk-binding-to-elements.html">
   </head>

--- a/_includes/samples/tk-element-databinding-color.html
+++ b/_includes/samples/tk-element-databinding-color.html
@@ -19,7 +19,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="toolkit/platform/platform.js"></script>
     <script src="toolkit/toolkit.js"></script>
     <link rel="import" href="tk-element-databinding-color.html">
   </head>

--- a/_includes/samples/tk-element-databinding.html
+++ b/_includes/samples/tk-element-databinding.html
@@ -17,7 +17,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="toolkit/platform/platform.js"></script>
     <script src="toolkit/toolkit.js"></script>
     <link rel="import" href="tk-element-databinding.html">
   </head>

--- a/_includes/samples/tk-element-event-binding.html
+++ b/_includes/samples/tk-element-event-binding.html
@@ -20,7 +20,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="toolkit/platform/platform.js"></script>
     <script src="toolkit/toolkit.js"></script>
     <link rel="import" href="tk-element-event-binding.html">
   </head>

--- a/_includes/samples/tk-element-property-public-publish.html
+++ b/_includes/samples/tk-element-property-public-publish.html
@@ -18,7 +18,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="toolkit/platform/platform.js"></script>
     <script src="toolkit/toolkit.js"></script>
     <link rel="import" href="tk-element-property-public-publish.html">
   </head>

--- a/_includes/samples/tk-element-property-public.html
+++ b/_includes/samples/tk-element-property-public.html
@@ -18,7 +18,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="toolkit/platform/platform.js"></script>
     <script src="toolkit/toolkit.js"></script>
     <link rel="import" href="tk-element-property-public.html">
   </head>

--- a/_includes/samples/tk-element-property.html
+++ b/_includes/samples/tk-element-property.html
@@ -18,7 +18,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="toolkit/platform/platform.js"></script>
     <script src="toolkit/toolkit.js"></script>
     <link rel="import" href="tk-element-property.html">
   </head>

--- a/_includes/samples/tk-element-public-access.html
+++ b/_includes/samples/tk-element-public-access.html
@@ -20,7 +20,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="toolkit/platform/platform.js"></script>
     <script src="toolkit/toolkit.js"></script>
     <link rel="import" href="tk-element-public-access.html">
   </head>

--- a/_includes/samples/tk-element-ready.html
+++ b/_includes/samples/tk-element-ready.html
@@ -20,7 +20,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="toolkit/platform/platform.js"></script>
     <script src="toolkit/toolkit.js"></script>
     <link rel="import" href="tk-element-ready.html">
   </head>

--- a/_includes/samples/tk-element.html
+++ b/_includes/samples/tk-element.html
@@ -20,7 +20,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="toolkit/platform/platform.js"></script>
     <script src="toolkit/toolkit.js"></script>
     <link rel="import" href="tk-element.html">
   </head>

--- a/_includes/samples/tk-node-finding.html
+++ b/_includes/samples/tk-node-finding.html
@@ -20,7 +20,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="toolkit/platform/platform.js"></script>
     <script src="toolkit/toolkit.js"></script>
     <!-- Load custom element -->
     <link rel="import" href="tk-node-finding.html">

--- a/_includes/samples/tk-twoway-binding.html
+++ b/_includes/samples/tk-twoway-binding.html
@@ -19,7 +19,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="toolkit/platform/platform.js"></script>
     <script src="toolkit/toolkit.js"></script>
     <link rel="import" href="tk-twoway-binding.html">
   </head>


### PR DESCRIPTION
toolkit.js now loads platform.js; this update removes platform.js from the code samples.
