### PR TITLE
Fixed typo on kernel explainer

### DIFF
--- a/toolkit-kernel-explainer.md
+++ b/toolkit-kernel-explainer.md
@@ -13,7 +13,7 @@ provided by a file named `toolkit.js`.
 
 ## Component declaration
 
-A web component declaration look like the following:
+A web component declaration looks like the following:
 
     <element name="tag-name">
       <template>


### PR DESCRIPTION
Found and fixed a minor typo in the kernel explainer on the docs site.
