### PR TITLE
Fix the link to the "discuss" page

### DIFF
--- a/_includes/top-nav.html
+++ b/_includes/top-nav.html
@@ -9,7 +9,7 @@
           <li class="icon github"><a href="https://github.com/toolkitchen/toolkit"><img src="/images/icons/github.png">View on Github</a></li>
           <li class="icon bug"><a href="https://github.com/toolkitchen/toolkit/issues/new"><img src="/images/icons/bug.png">File a bug</a></li>
           <li class="icon source"><a href="https://github.com/toolkitchen/toolkit/blob/master/CONTRIBUTING.md"><img src="/images/icons/source.png">Contribute</a></li>
-          <li class="icon talk"><a href="discuss.html"><img src="/images/icons/talk.png">Discuss</a></li>
+          <li class="icon talk"><a href="/discuss.html"><img src="/images/icons/talk.png">Discuss</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
The link is wrong on pages with a "deep" hierarchy (like in http://toolkitchen.github.io/platform/custom-elements.html).
