### PR TITLE
Fix typo on 'Getting Started' page

### DIFF
--- a/_includes/samples/tk-element-proto.html
+++ b/_includes/samples/tk-element-proto.html
@@ -4,7 +4,7 @@
   <div class="span8">
 <!-- Source tabs -->
 <ul id="myTab" class="nav nav-tabs">
-  <li class="active"><a href="#tk-element-proto" data-toggle="tab">tk-element.html</a></li>
+  <li class="active"><a href="#tk-element-proto" data-toggle="tab">tk-element-proto.html</a></li>
   <li><a href="#tk-element-proto-index" data-toggle="tab">index.html</a></li>
 </ul>
 


### PR DESCRIPTION
Change filename on tab to `tk-element-proto.html`
