### PR TITLE
Fix typo in other.md docs

### DIFF
--- a/docs/elements/other.md
+++ b/docs/elements/other.md
@@ -3,7 +3,7 @@ layout: default
 title: Toolkit-UI Elements
 ---
 
-Old and possibly outdated UI experiements.
+Old and possibly outdated UI experiments.
 
 **Repository:** [github.com/Polymer/toolkit-ui](https://github.com/Polymer/toolkit-ui)
 


### PR DESCRIPTION
Fix typo in experiments, used to be experiements.
