### PR TITLE
Add bower install, use to each element block

### DIFF
--- a/_plugins/directory.rb
+++ b/_plugins/directory.rb
@@ -126,8 +126,10 @@ module Jekyll
     end
 
     def bower_install_url(element)
+      
+      repo, element_path = element['path'].split('/')
 
-      "#{element['name']}"
+      "#{repo}"
     end
 
     def bower_use_url(element)


### PR DESCRIPTION
This change introduces a section after each element's API docs which includes a one-liner for how to install the relevant component from Bower (based on the repo/package name) and a one-liner for usage.

Please note that despite my best efforts, appengine dev server was only able to partially load the docs site locally so consider these changes a proof of concept that do require further testing :)
