### PR TITLE
Use standards-compliant linear gradients for IE

### DIFF
--- a/sass/elements/app-bar.scss
+++ b/sass/elements/app-bar.scss
@@ -22,7 +22,7 @@
 :host-context(site-banner[navgroup="start"], site-banner[navgroup="resources"], site-banner[navgroup="community"]) ::content .active,
 :host-context(site-banner[navgroup="start"], site-banner[navgroup="resources"], site-banner[navgroup="community"]) ::content .paper-button:hover {
   box-shadow: 0 1px 1px rgba(0, 0, 0, 1) inset, 0 -1px 1px rgba(0, 0, 0, 1) inset, 0 2px 0px rgba(0, 0, 0, 1) inset;
-  @include background(linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.8) 40%));
+  @include background(linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.8) 40%));
 }
 
 // TODO(ericbidelman): check with sorvell if :ancestor() is polyfill'd correctly.
@@ -33,7 +33,7 @@ polyfill-unscoped-rule {
   background: -webkit-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.8) 40%)  !important;
   background: -moz-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.8) 40%)  !important;
   background: -ms-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.8) 40%)  !important;
-  background: linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.8) 40%) !important;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.8) 40%) !important;
 }
 
 :host(.search-on) {

--- a/sass/paper-button.scss
+++ b/sass/paper-button.scss
@@ -51,7 +51,7 @@
     transition: none;
 
     &:hover, &.active {
-      @include background(linear-gradient(top, rgba(0, 0, 0, 0) 5%, rgba(0, 0, 0, 0.08) 40%));
+      @include background(linear-gradient(to bottom, rgba(0, 0, 0, 0) 5%, rgba(0, 0, 0, 0.08) 40%));
       box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2) inset, 0 -1px 1px rgba(0, 0, 0, 0.1) inset, 0 1px 0px rgba(0, 0, 0, 0.2) inset;
     }
   }


### PR DESCRIPTION
On http://www.polymer-project.org/docs/polymer/polymer.html, active `<app-bar>` buttons look entirely white on IE11. Need to use the standards-compliant "to ..." angle definition for non-prefixed `linear-gradient`.
