### PR TITLE
Add stronger warning label to polymer-*, polymer-ui-*, and other labs elements

### DIFF
--- a/_includes/labs.html
+++ b/_includes/labs.html
@@ -1,4 +1,4 @@
 <p class="alert alert-error">
   <polymer-ui-icon src="/images/picons/ic_notification_error_dark_.png" style="background-size:30px !important;"></polymer-ui-icon>
-  <b>Things may break!</b> This material is part of <a href="https://github.com/PolymerLabs">PolymerLabs</a>, our testing ground for experimental stuff. APIs, documentation, and demos may not be actively maintained.
+  <b>Things may break!</b> This material is part of <a href="https://github.com/PolymerLabs">PolymerLabs</a>, our testing ground for experimental stuff. APIs, documentation, and demos are <b>not actively supported</b> and it is recommended that you do not use these elements in production. If you need support, please use the <a href="http://polymer.github.io/core-docs/">Core Elements</a> collection.
 </p>


### PR DESCRIPTION
@sethladd mentioned that the current warning for labs elements does not make it clear that they are not actively supported. Added some stronger wording, and a link to steer people to core-\* elements
