### PR TITLE
Fix core-tooltip 404

### DIFF
--- a/elements/common_elements.html
+++ b/elements/common_elements.html
@@ -27,4 +27,5 @@ following command:
 <link rel="import" href="../elements/page-scrim.html">
 <link rel="import" href="../elements/dropdown-panel.html">
 
-<link rel="import" href="/elements/core-tooltip.html">
+<link rel="import" href="../components/core-tooltip/core-tooltip.html">
+


### PR DESCRIPTION
At least, this is occurring on my local copy; am I doing it wrong?
