### PR TITLE
Fix the fragment in a docs link

### DIFF
--- a/docs/polymer/binding-types.md
+++ b/docs/polymer/binding-types.md
@@ -18,7 +18,7 @@ There are several ways to bind data to a template. You can:
 **Note:** Binding templates only works inside {{site.project_title}} elements. For example, if a 
 `<template>` element is inserted directly into a page’s `<body>` tag, the the `bind` attribute 
 doesn’t work as described here. If you need to use template binding outside of a 
-{{site.project_title}} element, see [Using data binding outside of a {{site.project_title}} element](/docs/polymer/databinding-advanced.html#using-data-binding-outside-of-a-polymer-element). 
+{{site.project_title}} element, see [Using data binding outside of a {{site.project_title}} element](/docs/polymer/databinding-advanced.html#bindingoutside). 
 {: .alert .alert-info }
 
 When you use a binding _inside_ a template, you create a _node binding_, which binds a model value to a 


### PR DESCRIPTION
The link to the [Using data binding outside of a Polymer element](http://www.polymer-project.org/docs/polymer/databinding-advanced.html#bindingoutside) section of the "Advanced topics" guide wasn't using the correct URL fragment.
