### PR TITLE
updated "reserves" link in "attributes" section (link was broken)

### DIFF
--- a/docs/polymer/polymer.md
+++ b/docs/polymer/polymer.md
@@ -25,7 +25,7 @@ At the heart of {{site.project_title}} are [Custom Elements](/platform/custom-el
 
 ### Attributes
 
-{{site.project_title}} [reserves](https://github.com/Polymer/polymer/blob/master/src/declaration/attributes.js#L53) special attributes to be used on `<polymer-element>`:
+{{site.project_title}} [reserves](https://github.com/Polymer/polymer-dev/blob/fbae382197772afc123207ab8fc9379583ae50b0/src/declaration/attributes.js#L92) special attributes to be used on `<polymer-element>`:
 
 <table class="table responsive-table attributes-table">
   <tr>


### PR DESCRIPTION
link was no longer correct due to changes in project structure(?), but still exists in "commit history":(https://github.com/Polymer/polymer/blob/d8d0a4d15d7fe9bbd69a0ab4b52c1ef52ec58920/src/declaration/attributes.js#L53) (this is link to source code which was actual when writing this doc). 

polymer-dev is now project containing "attributes.js file":(https://github.com/Polymer/polymer-dev/blob/fbae382197772afc123207ab8fc9379583ae50b0/src/declaration/attributes.js#L92) (by executing git blame I was able to find what was in attributes.file as the date of docs creation "2013-10-04":(https://github.com/Polymer/docs/blame/513ea8f0859767bf8a05a6826024388f0b81bf2a/docs/polymer/polymer.md#L28) )
