### PR TITLE
Fix repeated typo from “x is y” to “x in y”, fixed use of non-possessive...

### DIFF
--- a/docs/elements/icons.md
+++ b/docs/elements/icons.md
@@ -70,7 +70,7 @@ This loads the *polymer* icon from the default iconset: <core-icon icon="polymer
 
 In the *iconset* directory
 of `core-icons` you can find more interesting icon sets.
-If the icon is not part of the default icon set, it's name needs to be prefixed with the name of the icon set (e.g. `set:iconname`). For example:
+If the icon is not part of the default icon set, its name needs to be prefixed with the name of the icon set (e.g. `set:iconname`). For example:
 
     <core-icon icon="social:cake"></core-icon>
 

--- a/docs/polymer/databinding-advanced.md
+++ b/docs/polymer/databinding-advanced.md
@@ -104,7 +104,7 @@ Consider the following templates:
 {% raw %}
     <template repeat="{{user in users}}">
       <p>{{user.name}}</p>
-      <template repeat="{{alias is user.aliases}}">
+      <template repeat="{{alias in user.aliases}}">
          <p>a.k.a. {{alias}}</p>
       </template>
     </template>
@@ -118,13 +118,13 @@ whitespace is added around the template instances for readability.)
 <pre class="prettyprint">
 &lt;template repeat="{{user in users}}">
   &lt;p>{{user.name}}&lt;/p>
-  &lt;template repeat="{{alias is user.aliases}}">
+  &lt;template repeat="{{alias in user.aliases}}">
      &lt;p>a.k.a. {{alias}}&lt;/p>
   &lt;/template>
 &lt;/template>
 
 &lt;p>Bob&lt;/p>              <span class="nocode" style="color: red"><em>⇐ start of 1st outer template instance</em></span>
-&lt;template repeat="{{alias is user.aliases}}">
+&lt;template repeat="{{alias in user.aliases}}">
   &lt;p>a.k.a. {{alias}}&lt;/p>
 &lt;/template>
 
@@ -135,7 +135,7 @@ whitespace is added around the template instances for readability.)
 
 
 &lt;p>Elaine&lt;/p>           <span class="nocode" style="color: red"><em>⇐ start of 2nd outer template instance</em></span>
-&lt;template repeat="{{alias is user.aliases}}">
+&lt;template repeat="{{alias in user.aliases}}">
   &lt;p>a.k.a. {{alias}}&lt;/p>
 &lt;/template>
 


### PR DESCRIPTION
The "Databinding: Advanced" page repeatedly says “repeat="{{alias _is_ user.aliases}}"”, whereas that should read “alias _in_ user.aliases”. Fixed.

The "Using core-icons" page uses the contraction “it's” in place of the possessive “its”.  Fixed.
