### PR TITLE
fix typo and broken link in runtime config doc

### DIFF
--- a/docs/polymer/runtime-config.md
+++ b/docs/polymer/runtime-config.md
@@ -191,7 +191,7 @@ set `Platform.ShadowCSS.strictStyling`.
 **Note:** We're setting `strictStyling` after loading `platform.js`.
 {: .alert .alert-info }
 
-More information on this feature can be found in the [Styling referencee](docs/polymer/styling.html#strictstyling).
+More information on this feature can be found in the [Styling reference](/docs/polymer/styling.html#strictstyling).
 
 <!--
 ## eval


### PR DESCRIPTION
drive-by pull request, just wanted to fix a broken link and a typo.
