### PR TITLE
Fix for a spelling error in the docs.

### DIFF
--- a/samples/components/tk-binding-to-elements.html
+++ b/samples/components/tk-binding-to-elements.html
@@ -22,7 +22,7 @@
       owner: "Eric",
       nameChanged: function() {
         if (this.name) {
-          // Insure name is capitalized
+          // Ensure name is capitalized
           this.name = this.name[0].toUpperCase() +
                       this.name.slice(1);
         }


### PR DESCRIPTION
It's "ensure", not "insure".
