### PR TITLE
Grunt tuneup

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,13 +104,24 @@ module.exports = function(grunt) {
       }
     },
 
+    compass: {
+      dist: {
+        options: {
+          sassDir: 'sass',
+          cssDir: 'css',
+          watch: true
+        }
+      }
+    },
+
     concurrent: {
       options: {
         logConcurrentOutput: true
       },
       target1: [
         'jekyll:serve',
-        'appengine:run:frontend'
+        'appengine:run:frontend',
+        'compass'
       ]
     }
 
@@ -119,6 +130,8 @@ module.exports = function(grunt) {
   // Plugin and grunt tasks.
   require('load-grunt-tasks')(grunt);
 
+  // Default task
+  // Task to run jekyll, app engine server, and compass watch
   grunt.registerTask('default', ['concurrent']);
 
   // Task to build docs.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "load-grunt-tasks": "~0.2.1",
     "grunt-contrib-watch": "~0.6.0",
     "grunt-appengine": "~0.1.5",
-    "grunt-concurrent": "~0.5.0"
+    "grunt-concurrent": "~0.5.0",
+    "grunt-contrib-compass": "~0.9.0"
   }
 }


### PR DESCRIPTION
This consolidates the `default` and `serve` grunt tasks, as well as the `compass watch` task. It uses [grunt-concurrent](https://github.com/sindresorhus/grunt-concurrent) to run all of the tasks simultaneously so you don't have to do so in individual terminal windows. Simply running `grunt` should give you everything you need to get the site up and running and in an editable state. 
