### PR TITLE
Fix indentation error in binding to markup example

### DIFF
--- a/samples/components/tk-binding-to-elements.html
+++ b/samples/components/tk-binding-to-elements.html
@@ -28,5 +28,5 @@
         }
       }
     });
-</script>
+  </script>
 </polymer-element>


### PR DESCRIPTION
It seems the indentation on lines 17 and 31 of the binding to markup example are inconsistent. The closing script tag on line 31 should be indented two spaces to match line 17.
#### before:

![before](https://cloud.githubusercontent.com/assets/5547203/3634136/a9ddfb3e-0f17-11e4-8b90-33715d92f4a4.png)
#### after:

![after](https://cloud.githubusercontent.com/assets/5547203/3634125/48b4705e-0f17-11e4-830f-db2e3ce720f9.png)
