### PR TITLE
typo 'plain'->'better'?

### DIFF
--- a/docs/polymer/polymer.md
+++ b/docs/polymer/polymer.md
@@ -636,7 +636,7 @@ All properties on {{site.project_title}} elements can be watched for changes by 
     <polymer-element name="g-cool" attributes="better best">
       <script>
         Polymer('g-cool', {
-          plain: '',
+          better: '',
           best: '',
           betterChanged: function(oldValue, newValue) {
             ...


### PR DESCRIPTION
I'm not sure, but it would make sense if 'plain' is replaced with 'better'.
As it is, I am wondering if listing properties in the 'attributes' attribute results in them being automatically created, but I am left wondering what 'plain' is all about.
