### PR TITLE
extra (wrong) quote in name-tag example

### DIFF
--- a/docs/polymer/binding-types.md
+++ b/docs/polymer/binding-types.md
@@ -296,7 +296,7 @@ properties.
 
     <polymer-element name="name-tag" attributes="person">
       <template>
-        Hello! My name is <span style="color:"{%raw%}{{person.nameColor}}{%endraw%}">
+        Hello! My name is <span style="color:{%raw%}{{person.nameColor}}{%endraw%}">
         {%raw%}{{person.name}}{%endraw%}</span>
       </template>
       <script>


### PR DESCRIPTION
The name tag example has a quote (") too many,
which makes the example HTML invalid
