### PR TITLE
Fix typo

### DIFF
--- a/docs/polymer/binding-types.md
+++ b/docs/polymer/binding-types.md
@@ -171,7 +171,7 @@ You can also use `if` with the  `repeat` attribute.
 {% raw %}
     <template>
       <template bind="{{myList as list}}">
-        <template repeat="{{items in list.items}}" if="{{list.showItems}}">
+        <template repeat="{{item in list.items}}" if="{{list.showItems}}">
           <li>{{item.name}}</li>
         </template>
       </template>


### PR DESCRIPTION
Fixes typo reported in #588. For consistency with other examples, change inner scope name to singular `item`.
