### PR TITLE
Update polyfill-next-selector docs for #637

### DIFF
--- a/docs/polymer/styling.md
+++ b/docs/polymer/styling.md
@@ -115,11 +115,11 @@ This means you only need `polyfill-next selector` when doing something that woul
 
 For example: `::content > *` will not work in a polyfilled browser because `> *` is not a valid selector. This selector could be rewritten as follows:
 
-    :host ::content > * { }
+    ::content > * { }
 
 or as:
 
-    polyfill-next-selector { content: ':host > *' }
+    polyfill-next-selector { content: '> *' }
     ::content > * { }
 
 Under native Shadow DOM nothing changes. Under the polyfill, the native selector is replaced with the one defined in its `polyfill-next-selector` predecessor.


### PR DESCRIPTION
Reviewer: @robdodson 

This change attempts to revise the `polyfill-next-selector` docs to only recommend using the feature when doing something that would not work if `::content` were removed. As part of this, I've tried to trim down some of the previous examples that focused on the `::content` usecase. If I misunderstood what we were aiming for here, feel free to holler.

https://github.com/Polymer/docs/issues/637
