### PR TITLE
Update call to Polymer with element name

### DIFF
--- a/docs/polymer/helpers.md
+++ b/docs/polymer/helpers.md
@@ -129,7 +129,7 @@ place the mixin in an HTML import and assign the mixin to a global variable:
 
     <polymer-element name="client-element">
     <script>
-      Polymer(Polymer.mixin({
+      Polymer('client-element', Polymer.mixin({
         // local prototype
       }, window.sharedMixin);
     </script>


### PR DESCRIPTION
Omitting element name from call to Polymer causes an Uncaught Element name could not be inferred.
