### PR TITLE
Clarified state of unresolved custom elements

### DIFF
--- a/docs/polymer/polymer.md
+++ b/docs/polymer/polymer.md
@@ -370,7 +370,7 @@ attributeChangedCallback | attributeChanged | An attribute was added, removed, o
 
 {{site.project_title}} parses element definitions and handles their upgrade _asynchronously_.
 If you prematurely fetch the element from the DOM before it has a chance to upgrade,
-you'll be working with an `HTMLUnknownElement`. {{site.project_title}} elements also support inline resources, such as stylesheets, that need to be loaded. These can cause [FOUC](http://en.wikipedia.org/wiki/Flash_of_unstyled_content) issues if they're not fully loaded prior to rendering an element. To avoid FOUC, {{site.project_title}} delays registering elements until stylesheets are fully loaded.
+you'll be working with a plain `HTMLElement`, instead of your custom element. {{site.project_title}} elements also support inline resources, such as stylesheets, that need to be loaded. These can cause [FOUC](http://en.wikipedia.org/wiki/Flash_of_unstyled_content) issues if they're not fully loaded prior to rendering an element. To avoid FOUC, {{site.project_title}} delays registering elements until stylesheets are fully loaded.
 
 To know when elements have been registered/upgraded, and thus ready to be interacted with, use the `polymer-ready` event.
 


### PR DESCRIPTION
Unknown elements with a hyphen are treated as unresolved custom elements, and inherit from HTMLElement, rather than HTMLUnknownElement.
