### PR TITLE
Change link to it's new location

### DIFF
--- a/docs/polymer/template.md
+++ b/docs/polymer/template.md
@@ -6,7 +6,7 @@ title: Template Binding
 subtitle: Library
 
 feature:
-  summary: Polymer's [TemplateBinding](https://github.com/polymer/TemplateBinding) library extends the capabilities of the [HTML Template Element](http://www.w3.org/TR/html-templates/) by enabling it to create, manage, and remove instances of content bound to data defined in JavaScript. Although internal in Polymer, it is also useful standalone.
+  summary: Polymer's [TemplateBinding](https://github.com/polymer/TemplateBinding) library extends the capabilities of the [HTML Template Element](http://www.w3.org/TR/html5/scripting-1.html#the-template-element) by enabling it to create, manage, and remove instances of content bound to data defined in JavaScript. Although internal in Polymer, it is also useful standalone.
 links:
 - "HTML5Rocks - HTML's New Template Tag": http://www.html5rocks.com/tutorials/webcomponents/template/
 ---


### PR DESCRIPTION
http://www.w3.org/TR/html-templates/

Work on this document has been discontinued and it should not be referenced or used as a basis for implementation. The features previously specified in this document are now specified in [HTML5](http://www.w3.org/TR/html5/scripting-1.html#the-template-element).
