### PR TITLE
Remove "/resources/discuss.html" item

### DIFF
--- a/elements/docs-menu.html
+++ b/elements/docs-menu.html
@@ -79,7 +79,6 @@
         <!-- <core-item label="Build status"><a href="/build/"></a></core-item> -->
         <core-item label="Releases"><a href="/resources/changelog.html"></a></core-item>
         <core-item label="FAQ"><a href="/resources/faq.html"></a></core-item>
-        <core-item label="Community"><a href="/resources/discuss.html"></a></core-item>
       </core-submenu>
     </core-submenu>
 


### PR DESCRIPTION
Broken link, there is already a Community item in Guides & Resources with the correct link.
