### PR TITLE
Fix typo in code example

### DIFF
--- a/articles/unit-testing-elements.md
+++ b/articles/unit-testing-elements.md
@@ -173,7 +173,7 @@ A simple assertion test using an assert-style test for this could be written as 
     selector.addEventListener('core-select', function(event) {
 
        // with an assert style
-       assert.equal(event.detail.item, '(item).);
+       assert.equal(event.detail.item, '(item)');
 
        // or an expect style
        expect(event.detail.item).to.equal('(item)');


### PR DESCRIPTION
Fix highlighting:

![screen shot 2014-12-10 at 09 25 07](https://cloud.githubusercontent.com/assets/746429/5367248/7f7a8a12-804e-11e4-9714-52158fec1442.png)
