### PR TITLE
Correct link for core-scaffold

### DIFF
--- a/docs/elements/layout-elements.md
+++ b/docs/elements/layout-elements.md
@@ -157,7 +157,7 @@ On desktop, resize the browser window to see the different modes.
 
 ### Side nav with `<core-scaffold>`
 
-The [`<core-scaffold>`](/docs/elements/core-elements.html#core-drawer-panel)  element
+The [`<core-scaffold>`](/docs/elements/core-elements.html#core-scaffold)  element
 assembles a commonly-used combination of components:
 a `<core-drawer-panel>` with a `<core-header-panel>` and `<core-toolbar>` for the
 main content area. It also includes a button to display the navigation drawer.


### PR DESCRIPTION
The link to the documentation for `core-scaffold` actually points to `core-drawer-panel`. 

Also, I note that all the demos in this document point to vulcanized versions of the code. This makes it harder to see how to use the layout components, e.g. by viewing source, than it could be.
