### PR TITLE
Remove var tags

### DIFF
--- a/docs/polymer/binding-types.md
+++ b/docs/polymer/binding-types.md
@@ -76,7 +76,7 @@ The simplest format for a repeating template is:
 {% endraw %}
 
 Refer to the current item in `array` using an empty binding expression {%raw%}`{{}}`{%endraw%}, which matches
-the current binding scope. Refer to a property of the current item as {%raw%}`{{<var>propertyname</var>}}`{%endraw%}. 
+the current binding scope. Refer to a property of the current item as {%raw%}`{{propertyname}}`{%endraw%}. 
 
 Like the `bind` attribute, the `repeat` attribute supports named scopes:
 


### PR DESCRIPTION
@arthurevans as I was reading the docs I noticed these `<var>` tags are being printed out. That seems like an error unless I'm mistaken?
