### PR TITLE
Make link for new github repo open in new tab

### DIFF
--- a/docs/start/reusableelements.md
+++ b/docs/start/reusableelements.md
@@ -51,7 +51,7 @@ to the URL `localhost:8000/test-element/demo.html`.
 
 Once you're happy with your element, you’ll want to push the code for `test-element` to GitHub and tag a new version of it.
 
-Click [here](https://github.com/new) to create a new repository on GitHub. Try to keep the name of the repository consistent with the naming of your element (e.g if your element is `<test-element>`, your repository should be called `test-element`).
+Click <a href="https://github.com/new" target="_blank">here</a> to create a new repository on GitHub. Try to keep the name of the repository consistent with the naming of your element (e.g if your element is `<test-element>`, your repository should be called `test-element`).
 
 Next, follow the steps below:
 


### PR DESCRIPTION
Unfortunately GitHub markdown does not support opening links in a new tab. This change replaces the link to create a new github repo with some html that does that.

Here's a github issue thread that shows that markdown is not likely to support this natively in the future: https://github.com/mojombo/github-flavored-markdown/issues/28
