### PR TITLE
Updates to conform to the new <context-free-parser> output.

### DIFF
--- a/elements/component-docs.html
+++ b/elements/component-docs.html
@@ -64,10 +64,40 @@
     <div class="main" on-marked-js-highlight="{{prettyPrint}}">
       <h1>{{data.name}}</h1>
 
-      <template if="{{data.extends}}">
-        <section class="top">
-          <h3>Extends: <a href="{{data.extends | collectionPrefix}}-elements.html#{{data.extends}}">{{data.extends}}</a></h3>
-        </section>
+      <template bind="{{data as data}}" if="{{data.extends || data.mixins}}">
+        <div class="inheritance">
+          <template if="{{data.extends}}">
+            <section class="top extends" layout horizontal center>
+              <h3 data-anchor-id="{{data.name}}.extends">
+                Extends:
+                <template repeat="{{e, i in data.extends}}">
+                  <template if="{{e.url}}">
+                    <a href="{{e.url}}">{{e.name}}</a>
+                  </template>
+                  <template if="{{!e.url}}">
+                    <a href="{{e.name | collectionPrefix}}-elements.html#{{e.name}}">{{e.name}}</a>
+                  </template>
+                  <span hidden?="{{i == data.extends.length - 1}}">,</span>
+                </template>
+              </h3>
+            </section>
+          </template>
+
+          <template if="{{data.mixins}}">
+            <section class="top mixins" layout horizontal center>
+              <h3 data-anchor-id="{{data.name}}.mixins">
+                Mixins:
+                <template repeat="{{e, i in data.mixins}}">
+                  <template if="{{e.url}}">
+                    <a href="{{e.url ? e.url : e.name}}">{{e.name}}</a>
+                  </template>
+                  <template if="{{!e.url}}"><span>{{e.name}}</span></template>
+                  <span hidden?="{{i == data.mixins.length - 1}}">,</span>
+                </template>
+              </h3>
+            </section>
+          </template>
+        </div>
       </template>
 
       <template if="{{downloadable}}">


### PR DESCRIPTION
@ebidel:

This mostly matches the changes to `<core-doc-viewer>` in https://github.com/Polymer/core-doc-viewer/pull/34, with some tweaks to get it to use the proper URL for element collections.

I'm using `data-anchor-id` attributes here under the assumption that's what's going to be used for deep-linking once https://github.com/Polymer/docs/pull/836 goes into effect, but if we go with a different attribute name, I can swap that out.

I left the existing styling as-is rather than copying over the styles that were added to `<core-doc-viewer>` to keep things consistent.

It looks like:
![6534933591883776](https://cloud.githubusercontent.com/assets/1749548/5462063/974b0690-853e-11e4-8fdf-bbd368c2d475.png)
