### PR TITLE
Take banner height into account when scrolling to anchor

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -149,8 +149,14 @@ function injectPage(url, opt_addToHistory) {
 
     // Scroll to hash, otherwise goto top of the loaded page.
     if (location.hash) {
-      var scrollTargetEl = document.querySelector(location.hash);
-      scrollTargetEl && scrollTargetEl.scrollIntoView(true, {behavior: 'smooth'});
+      // Wrap this scrolling logic in a timeout to ensure that the <template>s are fully
+      // stamped out, and that if the user agent tries to reset the scroll position (e.g.
+      // after a reload), our logic kicks in afterward.
+      // See https://github.com/Polymer/docs/pull/836 for a discussion of this behavior.
+      window.setTimeout(function() {
+        var scrollTargetEl = document.querySelector(location.hash);
+        scrollTargetEl && exports.scrollTo(0, scrollTargetEl.offsetTop - siteBanner.offsetHeight);
+      }, 200);
     } else {
       exports.scrollTo(0, 0);
     }


### PR DESCRIPTION
@ebidel @arthurevans & co.:

Similar to some of the logic in https://github.com/Polymer/docs/pull/836, this adjusts the scroll-to-anchor-on-inject-page logic to take the height of the site banner into account, which closes #821. This particular logic only kicks in when the page content is injected.
