### PR TITLE
Check that value exists in filter functions

### DIFF
--- a/docs/polymer/expressions.md
+++ b/docs/polymer/expressions.md
@@ -213,7 +213,9 @@ your element by adding a method to the element's prototype. For example, to add 
     Polymer('greeting-tag', {
       ...
       toUpperCase: function(value) {
-        return value.toUpperCase();
+        if (value) {
+          return value.toUpperCase();
+        }
       },
 
 And use the filter like this:
@@ -230,10 +232,14 @@ in lowercase, you could modify the `toUpperCase` as follows:
 
     toUpperCase: {
       toDOM: function(value) {
-        return value.toUpperCase();
+        if (value) {
+          return value.toUpperCase();
+        }
       },
       toModel: function(value) {
-        return value.toLowerCase();
+        if (value) {
+          return value.toLowerCase();
+        }
       }
     }
 
@@ -255,7 +261,9 @@ You can pass parameters to a filter. For example:
 The code for the `toFixed` filter could look like this:
 
     toFixed: function(value, precision) {
-      return Number(value).toFixed(precision);
+      if (value) {
+        return Number(value).toFixed(precision);
+      }
     }
 
 The parameters passed to a filter are observed for changes.
@@ -290,7 +298,9 @@ To register `uppercase` as a global filter, add it to the prototype for
 
 {% raw %}
     PolymerExpressions.prototype.uppercase = function(input) {
-      return input.toUpperCase();
+      if (value) {
+        return input.toUpperCase();
+      }
     };
 {% endraw %}
 
@@ -305,9 +315,11 @@ Filter definition:
 
 {% raw %}
     PolymerExpressions.prototype.startsWith = function (input, letter) {
-      return input.filter(function(item){
-        return item[0] === letter;
-      });
+      if (input) {
+        return input.filter(function(item){
+          return item[0] === letter;
+        });
+      }
     };
 {% endraw %}
 


### PR DESCRIPTION
It seems like a lot of people are confused about why they're seeing the console error "Cannot read property 'toUpperCase' of undefined" when copying the example from the documentation.
http://stackoverflow.com/questions/23681366/polymer-custom-filters

It may be helpful to include a check that value is defined before doing any operation on it.