### PR TITLE
correcting some rendering typos

### DIFF
--- a/articles/spa.md
+++ b/articles/spa.md
@@ -421,7 +421,8 @@ Render a different icon for the selected nav item:
 
 {%raw%}
     <paper-item noink>
-      &lt;ore-icon icon="label{{route != page.hash ? '-outline' : ''}}">&lt;/core-icon>
+      <core-icon icon="label{{route != page.hash ? '-outline' : ''}}"></core-icon>
+    </paper-item>
 {%endraw%}
 
 Tapping on a page cycles through the pages:


### PR DESCRIPTION
correcting some rendering typos in the single-page app. Some of the "<" symbols came out as &lt;