### PR TITLE
Remove extraneous change dir to parent in setup

### DIFF
--- a/articles/unit-testing-elements.md
+++ b/articles/unit-testing-elements.md
@@ -35,7 +35,6 @@ Our boilerplate for new Polymer elements, [`<seed-element>`](https://github.com/
         $ cd seed-element
         $ bower install
         $ npm install -g web-component-tester
-        $ cd ..
         $ wct
 
 The WCT (web-component-tester) tool will run your tests in multiple browsers at once. If all goes well, you should see some output resembling the following in your terminal:


### PR DESCRIPTION
In my repo, wct needs to be at the project root.  The cd .. moves the developer to the parent directory containing the repo.