### PR TITLE
Remove extraneous commands

### DIFF
--- a/articles/unit-testing-elements.md
+++ b/articles/unit-testing-elements.md
@@ -30,12 +30,10 @@ Okay, not quite, but you need tests because you're not Chuck Norris. Chuck Norri
 
 Our boilerplate for new Polymer elements, [`<seed-element>`](https://github.com/PolymerLabs/seed-element), contains everything you need to start writing unit tests for your element. To fetch it and install all the dependencies you'll need, run the following commands in the terminal:
 
-        $ mkdir development
         $ git clone git://github.com/PolymerLabs/seed-element.git
         $ cd seed-element
         $ bower install
         $ npm install -g web-component-tester
-        $ cd ..
         $ wct
 
 The WCT (web-component-tester) tool will run your tests in multiple browsers at once. If all goes well, you should see some output resembling the following in your terminal:


### PR DESCRIPTION
We create (and never use) a development directory.  And then cd .. to the parent of the repo - where the wct command will fail.