### PR TITLE
Updated latest_version configuration to 0.5.2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,6 @@ kramdown:
 # Site globals used throughout docs.
 project_title: Polymer
 project_status: 'Dev preview'
-latest_version: 0.5.1
+latest_version: 0.5.2
 add_permalinks: true # adds permalinks to heading tags.
 load_disqus: true


### PR DESCRIPTION
As version 0.5.2 is available, this version should be recommended on the website (https://github.com/Polymer/polymer/releases).