### PR TITLE
Restore the development directory

### DIFF
--- a/articles/unit-testing-elements.md
+++ b/articles/unit-testing-elements.md
@@ -30,6 +30,8 @@ Okay, not quite, but you need tests because you're not Chuck Norris. Chuck Norri
 
 Our boilerplate for new Polymer elements, [`<seed-element>`](https://github.com/PolymerLabs/seed-element), contains everything you need to start writing unit tests for your element. To fetch it and install all the dependencies you'll need, run the following commands in the terminal:
 
+        $ mkdir development
+        $ cd development
         $ git clone git://github.com/PolymerLabs/seed-element.git
         $ cd seed-element
         $ bower install


### PR DESCRIPTION
After my previous patch was merged, I noticed a problem I was not aware of.  This repo uses '..' in the .bowerrc file so that it installs dependencies in the PARENT of the repo directory.  This patch replaces the development directory, and also cd's to it so that the bower installed dependency files are not placed in a directory we did not create.