### PR TITLE
correct code mistake

### DIFF
--- a/articles/spa.md
+++ b/articles/spa.md
@@ -397,7 +397,7 @@ First, update the data model to include content URLs:
       ...
     ];
 
-Then add the selectedModel attribute to the `<core-menu>` element to bind it to the currently selected page, and change the menu links to point at  `page.url` instead of the hash:
+Then add the `selectedModel` attribute to the `<core-menu>` element to bind it to the currently selected page, and change the menu links to point at  `page.url` instead of the hash:
 
 {%raw%}
 <pre>

--- a/articles/spa.md
+++ b/articles/spa.md
@@ -397,13 +397,17 @@ First, update the data model to include content URLs:
       ...
     ];
 
-Then change the menu links to point at  `page.url` instead of the hash:
+Then add a parameter to the `<core-menu>` elements and change the menu links to point at  `page.url` instead of the hash:
 
 {%raw%}
 <pre>
-&lt;paper-item hash="{{page.hash}}" noink>
-  <b>&lt;a _href="{{page.url}}">{{page.name}}&lt;/a></b>
-&lt;/paper-item>
+&lt;core-menu ... selectedModel="{{selectedPage}}">
+  ...
+  &lt;paper-item hash="{{page.hash}}" noink>
+    <b>&lt;a _href="{{page.url}}">{{page.name}}&lt;/a></b>
+  &lt;/paper-item>
+  ...
+&lt;core-menu>
 </pre>
 {%endraw%}
 

--- a/articles/spa.md
+++ b/articles/spa.md
@@ -397,7 +397,7 @@ First, update the data model to include content URLs:
       ...
     ];
 
-Then add a parameter to the `<core-menu>` elements and change the menu links to point at  `page.url` instead of the hash:
+Then add the selectedModel attribute to the `<core-menu>` element to bind it to the currently selected page, and change the menu links to point at  `page.url` instead of the hash:
 
 {%raw%}
 <pre>


### PR DESCRIPTION
If you follow the directions in the tutorial for **Loading content on-demand**, the app doesn't actually load the external content. This is because `selectedModel="{{selectedPage}}"` was missing.