### PR TITLE
Reset `<body>` scrolling when leaving mobile view

### DIFF
--- a/elements/app-drawer.html
+++ b/elements/app-drawer.html
@@ -114,6 +114,7 @@
           this.controller.left = 0;
           this.controller.right = 315;
           this.active = false;
+          document.body.classList.remove('noscroll');
         }
       }
     });


### PR DESCRIPTION
The “noscroll” class is added when the drawer is opened, and so when the
view changes from mobile when the drawer is open the “noscroll" needs to
be removed to re-enable scrolling on the document.

Fixes https://github.com/Polymer/polymer/issues/1089