### PR TITLE
Don't AJAXify middle mouse button clicks.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -194,7 +194,7 @@ function ajaxifySite() {
 
   document.addEventListener('click', function(e) {
     // Allow users to open new tabs.
-    if (e.metaKey || e.ctrlKey) {
+    if (e.metaKey || e.ctrlKey || e.which == 2) {
       return;
     }
 


### PR DESCRIPTION
In the better-late-than-never department, fixes #509. Don't AJAXify step for middle-mouse-button clicks so the browser can open them in a new tab.

Tested on Chrome and Safari for Mac (both of which display the issue on pp.org currently), plus Firefox for Mac and IE 11 (which don't display the issue, and don't appear to be impacted by the change).