### PR TITLE
Updated non working core-media-query example

### DIFF
--- a/docs/polymer/layout-attrs.md
+++ b/docs/polymer/layout-attrs.md
@@ -121,14 +121,16 @@ Otherwise, the layout becomes horizontal and the elements are laid out
 normally.
 
 {% raw %}
-    <core-media-query query="max-width: 640px"
-                      queryMatches="{{phoneScreen}}"></core-media-query>
-    <div layout vertical?="{{phoneScreen}}"
-         horizontal?="{{!phoneScreen}}">
-      <div auto-vertical>Alpha</div>
-      <div auto-vertical>Beta</div>
-      <div auto-vertical>Gamma</div>
-    </div>
+    <template is="auto-binding">
+      <core-media-query query="max-width: 640px"
+                        queryMatches="{{phoneScreen}}"></core-media-query>
+      <div layout vertical?="{{phoneScreen}}"
+           horizontal?="{{!phoneScreen}}">
+        <div auto-vertical>Alpha</div>
+        <div auto-vertical>Beta</div>
+        <div auto-vertical>Gamma</div>
+      </div>
+    </template>
 {% endraw %}
 
 <div vertical layout class="demo" style="height:170px">


### PR DESCRIPTION
This documentation page:
https://www.polymer-project.org/docs/polymer/layout-attrs.html
makes mention of how to use the core-media-query to auto select between a vertical and horizontal alignment. However, when just dropping this code into a page for testing, it did not seem to work(nor does it appear to work on the documentation page itself on my chrome browser).

I searched and found that wrapping the core-media-query block in (template is="auto-binding") (/template) got it working just fine. Source:
http://stackoverflow.com/questions/27298131/polymer-core-media-query-element-for-responsive-layouts