### PR TITLE
Keeping output in sync with respective sample snippet

### DIFF
--- a/0.5/samples/layout-attr.html
+++ b/0.5/samples/layout-attr.html
@@ -20,7 +20,7 @@
 </head>
 <body fullbleed vertical layout>
 
-  <div flex class="demo">This &lt;body> is fullbleed!</div>
+  <div flex class="demo">Fitting a fullbleed body.</div>
 
 </body>
 </html>


### PR DESCRIPTION
The snippet in polymer/layout-attrs page, under 'full bleed' section, mentions text content as "Fitting a fullbleed body."
However, the linked iframe source was mentioning 'This <body> is fullbleed!'

So chose to update the sample with the text as provided in the documentation page.