### PR TITLE
Add element name to title for doc pages

### DIFF
--- a/_plugins/element_pages.rb
+++ b/_plugins/element_pages.rb
@@ -16,7 +16,7 @@ module Jekyll
       isPaperElement = element.start_with? "paper-"
 
       self.data['element'] = element
-      self.data['title'] = "Polymer #{isPaperElement ? 'paper' : 'core'} elements"
+      self.data['title'] = "#{element} - Polymer #{isPaperElement ? 'paper' : 'core'} elements"
       self.data['type'] = 'elements'
       self.data['shortname'] = 'Elements'
       if isPaperElement


### PR DESCRIPTION
Adds the element's name to the `<title>` on docs pages.

Related to https://github.com/Polymer/docs/issues/940#issuecomment-78173315