### PR TITLE
Redirect old element pages

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -174,8 +174,30 @@ function injectPage(url, opt_addToHistory) {
   xhr.send();
 }
 
+function redirectOldAPIDocs() {
+  // Old API reference URLs have the page name in the hash. After
+  // server-side redirects, they end up as "docs/elements/#page-name".
+  // Rewrite here to "docs/elements/page-name.html"
+  var oldAPILanding = 'docs/elements/'
+  var path = window.location.pathname;
+  var hash = window.location.hash;
+  var position = path.length - oldAPILanding.length;
+  var lastIndex =  path.indexOf(oldAPILanding, position);
+  if (lastIndex !== -1 && lastIndex == position) {
+    if (hash) {
+      var newPath = path + hash.slice(1) + '.html';
+      window.location.hash = '';
+      window.location.pathname = newPath;
+    }
+  }
+}
+
 function initPage(opt_inDoc) {
   var doc = opt_inDoc || document;
+
+  // TODO: surely there's a better way to do this?
+  redirectOldAPIDocs();
+
 
   // TODO: do this at build time.
   addPermalinkHeadings(doc);

--- a/js/app.js
+++ b/js/app.js
@@ -174,10 +174,12 @@ function injectPage(url, opt_addToHistory) {
   xhr.send();
 }
 
+// Old API reference URLs have the page name in the hash. After
+// server-side redirects, they end up as "docs/elements/#page-name"
+// The page name may be followed by a deep link, like ".attributes.data".
+// Rewrite here to "docs/elements/page-name.html", leaving any hash
+// in place to preserve the deep link.
 function redirectOldAPIDocs() {
-  // Old API reference URLs have the page name in the hash. After
-  // server-side redirects, they end up as "docs/elements/#page-name".
-  // Rewrite here to "docs/elements/page-name.html"
   var oldAPILanding = 'docs/elements/'
   var path = window.location.pathname;
   var hash = window.location.hash;
@@ -185,9 +187,7 @@ function redirectOldAPIDocs() {
   var lastIndex =  path.indexOf(oldAPILanding, position);
   if (lastIndex !== -1 && lastIndex == position) {
     if (hash) {
-      var newPath = path + hash.slice(1) + '.html';
-      window.location.hash = '';
-      window.location.pathname = newPath;
+      location.href = location.href.replace(/(\/docs\/elements\/)#([^.]*)(.*)$/, '$1$2.html#$2$3')
     }
   }
 }


### PR DESCRIPTION
The PR formerly known as https://github.com/Polymer/docs/pull/992, but with clean history.

Now with proper handling of deep-link hashes and less . The following are examples of URLs that should work:

http://localhost:3000/0.5/docs/elements/#core-list
http://localhost:3000/0.5/docs/elements/#core-list.attributes.data

Note that the deep-link hash also needs to contain the element name for it to work 
correctly, so the redirect for the second link should look like this:

http://localhost:3000/0.5/docs/elements/core-list.html#core-list.attributes.data
