### PR TITLE
Fixed broken link

### DIFF
--- a/0.5/docs/start/tutorial/step-2.md
+++ b/0.5/docs/start/tutorial/step-2.md
@@ -41,7 +41,7 @@ In this step, you'll learn about:
 <aside class="alert alert-info">
 <p><b>Learn more:</b>Shadow DOM provides you a way to add a local DOM tree
 inside a DOM element, with local styles and markup that are decoupled from the rest of the web page.</p>
-<p>To learn more about shadow DOM, see the <a href="../../platform/shadow-dom.html">
+<p>To learn more about shadow DOM, see the <a href="../../../platform/shadow-dom.html">
 Shadow DOM polyfill docs</a>.</p>
 </aside>
 


### PR DESCRIPTION
The "Shadow DOM polyfill docs" link on https://www.polymer-project.org/0.5/docs/start/tutorial/step-2.html goes to https://www.polymer-project.org/0.5/docs/platform/shadow-dom.html, which is 404. https://www.polymer-project.org/0.5/platform/shadow-dom.html is a URL that exists, so adding `../` to the relative URL should work. But if this HTML is used in other contexts, that might not be the right fix.