### PR TITLE
Update unit-testing-elements.md

### DIFF
--- a/0.5/articles/unit-testing-elements.md
+++ b/0.5/articles/unit-testing-elements.md
@@ -35,6 +35,7 @@ Our boilerplate for new Polymer elements, [`<seed-element>`](https://github.com/
         $ cd development
         $ git clone git://github.com/PolymerLabs/seed-element.git
         $ cd seed-element
+        $ echo '{ "directory": "../" }' > .bowerrc
         $ bower install
         $ npm install -g web-component-tester
         $ wct

--- a/0.5/articles/unit-testing-elements.md
+++ b/0.5/articles/unit-testing-elements.md
@@ -34,8 +34,8 @@ Our boilerplate for new Polymer elements, [`<seed-element>`](https://github.com/
         $ mkdir development
         $ cd development
         $ git clone git://github.com/PolymerLabs/seed-element.git
+        $ git checkout v0.1.5
         $ cd seed-element
-        $ echo '{ "directory": "../" }' > .bowerrc
         $ bower install
         $ npm install -g web-component-tester
         $ wct


### PR DESCRIPTION
The quick start fails unless there is a .bowerrc file or all the paths are changed to point at the default bower_components directory.  This is one way to fix the issue.