### PR TITLE
fixed the forward button

### DIFF
--- a/0.5/docs/start/tutorial/step-3.md
+++ b/0.5/docs/start/tutorial/step-3.md
@@ -201,6 +201,6 @@ If you have any problems, check your work against the files in the `step-3` fold
   <paper-button><core-icon icon="arrow-back"></core-icon>Step 2: Creating your own element</paper-button>
 </a>
 <a href="step-4.html">
-  <paper-button raises><core-icon icon="arrow-forward"></core-icon>Step 4: Finishing touches</paper-button>
+  <paper-button raised><core-icon icon="arrow-forward"></core-icon>Step 4: Finishing touches</paper-button>
 </a>
 </div>


### PR DESCRIPTION
The forward button doesn't look like the other forward buttons on other pages. This is because, it has a ``raises`` class instead of ``raised`` one. See screenshots for details.
(Tested on Safari 8.0.5 and Google Chrome 42.0.2311.135)

![screen shot 2015-04-30 at 1 58 31 pm](https://cloud.githubusercontent.com/assets/7308807/7422513/608675b8-ef42-11e4-9e68-a7ae1198f172.png)


![screen shot 2015-04-30 at 1 58 18 pm](https://cloud.githubusercontent.com/assets/7308807/7422511/5ec07cba-ef42-11e4-9535-3a803414bb2e.png)