### PR TITLE
Misc fixes (attribute binding, css mixin syntax, others)

### DIFF
--- a/0.9/docs/devguide/data-binding.md
+++ b/0.9/docs/devguide/data-binding.md
@@ -496,8 +496,13 @@ are used for CSS or for for interoperability with elements that require using an
 attribute-based API.
 
 To bind to an attribute, use `$=` rather than `=`.  This
-results in in a call to <code><var>element</var>.setAttribute(<var>attr</var>, <var>value</var>);</code>, as opposed to
-<var>element</var>.<var>property</var> = <var>value</var>;`.
+results in in a call to:
+
+<code><var>element</var>.setAttribute(<var>attr</var>, <var>value</var>);</code>
+
+As opposed to:
+
+<var>element</var>.<var>property</var> = <var>value</var>;
 
     <template>
       {% raw %}
@@ -511,8 +516,8 @@ results in in a call to <code><var>element</var>.setAttribute(<var>attr</var>, <
       {% endraw %}
     </template>
 
-Values are serialized according to the value's _current_ type, as described for 
-[attribute serialization](properties.html#attribute-serialization).
+Attribute bindings are always one-way, host-to-child. Values are serialized according to 
+the value's _current_ type, as described for [attribute serialization](properties.html#attribute-serialization).
 
 Again, as values must be serialized to strings when binding to attributes, it is
 always more performant to use property binding for pure data propagation.

--- a/0.9/docs/devguide/settings.md
+++ b/0.9/docs/devguide/settings.md
@@ -34,11 +34,11 @@ stub.
 Settings can also be switched on the URL query string:
 
 ```
-http://myserver.com/test-app/index.html?polymer-dom=shadow
+http://myserver.com/test-app/index.html?dom=shadow
 ```
 
 Available settings:
 
-* `polymer-dom` - options:
+* `dom` - options:
     * `shady`. All local DOM is rendered using shady DOM, even where shadow DOM is supported (current default).
     * `shadow`. Local DOM is rendered using shadow DOM where supported (this will be the default in the future).

--- a/0.9/docs/devguide/styling.md
+++ b/0.9/docs/devguide/styling.md
@@ -229,27 +229,46 @@ Example usage of `my-toolbar`:
 
     </dom-module>
 
-The `--my-toolbar-title-color` property will only affect the color of the title
-element encapsulated in `my-toolbar`'s internal implementation.  If in the
-future the `my-toolbar` author chose to rename the `title` class or otherwise
-restructure the internal details of `my-toolbar`, users are shielded from this
-change via the indirection afforded by custom properties.
+The `--my-toolbar-title-color` property only affects the color of the title
+element encapsulated in `my-toolbar`'s internal implementation.  In the
+future the `my-toolbar` author can rename the `title` class or 
+restructure the internal details of `my-toolbar` without changing the custom
+property exposed to users.
 
 Thus, custom CSS properties introduce a powerful way for element authors to
 expose a theming API to their users in a way that naturally fits right alongside
-normal CSS styling and avoids the problems with `/deep/` and `::shadow`, and is
+normal CSS styling and avoids the problems with `/deep/` and `::shadow`. It is
 already on a standards track with shipping implementation by Mozilla and planned
 support by Chrome.
 
-However, it may be tedious (or impossible) for an element author to anticipate
+### Custom CSS mixins
+
+It may be tedious (or impossible) for an element author to anticipate
 and expose every possible CSS property that may be important for theming an
 element as individual CSS properties (for example, what if a user needed to
-ajust the `opacity` of the toolbar title?).  For this reason, the custom
+adjust the `opacity` of the toolbar title?).  
+
+For this reason, the custom
 properties shim included in Polymer includes an experimental extension allowing
 a bag of CSS properties to be defined as a custom property and allowing all
 properties in the bag to be applied to a specific CSS rule in an element's local
 DOM.  For this, we introduce a mixin capability that is analogous to `var`,
 but allows an entire bag of properties to be mixed in.
+
+Use `@apply` to apply a mixin:
+
+<pre>@apply(--<var>mixin-name</var>)</pre>
+
+Defining a mixin is just like defining a custom property, but the 
+value is an object that defines one more more rules:
+
+<pre><var>selector</var> {
+  --<var>mixin-name</var>: {
+    /* rules */
+  };
+}</pre>
+
+Note that the _definition_ ends with a semicolon, and the `@apply` line **does not**.
 
 Example:
 
@@ -287,10 +306,10 @@ Example usage of `my-toolbar`:
             background-color: green;
             border-radius: 4px;
             border: 1px solid gray;
-          }
+          };
           --my-toolbar-title-theme: {
             color: green;
-          }
+          };
         }
 
         /* Make only toolbars with the .warning class red and bold */
@@ -298,7 +317,7 @@ Example usage of `my-toolbar`:
           --my-toolbar-title-theme: {
             color: red;
             font-weight: bold;
-          }
+          };
         }
 
       </style>
@@ -313,6 +332,7 @@ Example usage of `my-toolbar`:
       </template>
 
     </dom-module>
+
 
 ### Custom Properties Shim - Limitations and API details
 

--- a/0.9/docs/migration.md
+++ b/0.9/docs/migration.md
@@ -674,6 +674,21 @@ Note that `trackstart` and `trackend` are  not fired as separate events, but as 
 
 For more details, see [Gesture events](devguide/events.html#gestures).
 
+## Vulcanize
+
+The latest versions of the [`vulcanize`](https://github.com/Polymer/vulcanize) tool are updated for the new {{site.project_title}}
+element format. Newer versions of vulcanize are **not** backward compatible:
+
+* `vulcanize` versions 1.0 and higher are compatible with {{site.project_title}} 0.8+ **only**. The current version is 1.4.2.
+* `vulcanize` versions below 1.0 are compatible with {{site.project_title}} 0.5 **only**. The current version is 0.7.10.
+
+The `--csp` option to `vulcanize` is now a separate utility, [`crisper`](https://github.com/PolymerLabs/crisper). Typical usage 
+is:
+
+    vulcanize --inline-scripts --inline-css target.html | \
+        crisper --html build.html --js build.js
+
+For more details on the `vulcanize` arguments, see the [README](https://github.com/Polymer/vulcanize).
 
 ## Manipulating DOM {#dom-apis}
 
@@ -809,7 +824,7 @@ property accessors, generated at element registration time, which provides high
 performance with minimal cost at instantiation time. The main differences in
 binding are:
 
-*   No expression support. Binding is to properties or paths only. (The negation
+*   No expression or filter support. Binding is to properties or paths only. (The negation
     operator, `!`, is supported for convenience.) In many cases, computed
     properties can be used in place of complex binding expressions.
 
@@ -832,10 +847,16 @@ Before:
 After:
 
     {% raw %}
-    <my-foo fullname="{{computeFullName}}">
+    <my-foo fullname="{{computeFullName(firstname, lastname)}}">
             Hi, my name is <span>{{firstname}}</span>.
     </my-foo>
     {% endraw %}
+
+    ...
+
+    computeFullName: function(first, last) {
+      return first + ' ' + last;
+    }
 
 Support for repeating templates, conditional templates and autobinding templates 
 is provided by [helper elements](devguide/templates.html). 
@@ -905,7 +926,7 @@ Change this expression to
 
 For example:
 
-    <div hidden$="[[isHidden]]">Boo!</div>
+    <div hidden$="{%raw%}{{isHidden}}{%endraw%}">Boo!</div>
 
 The new version is more general-purpose: it can handle both boolean and valued
 attributes. The property value is serialized, just like it is  for reflected
@@ -914,7 +935,10 @@ in the Developer guide for details).
 
 For example:
 
-    <input type="checkbox" checked$="[[isComplete]]" aria-label$="[[completedLabel]]">
+    {%raw%}
+    <input type="checkbox" checked$="{{isComplete}}" 
+        aria-label$="{{completedLabel}}">
+    {%endraw%}
 
 If `isComplete` is `true` and `completedLabel` is "Completed", this appears as:
  

--- a/0.9/docs/migration.md
+++ b/0.9/docs/migration.md
@@ -22,6 +22,7 @@ When migrating, the following items can be translated easily from 0.5 to this re
 *   [Layout attributes](#layout-attributes)
 *   [Use WebComponentsReady instead of the polymer-ready event](#polymer-ready)
 *   [Gestures](#gestures)
+*   [Vulcanize](#vulcanize)
 
 Other areas may require more changes to work correctly, either because there are
 significant API changes from 0.5, feature gaps, or both. These areas include:
@@ -674,7 +675,7 @@ Note that `trackstart` and `trackend` are  not fired as separate events, but as 
 
 For more details, see [Gesture events](devguide/events.html#gestures).
 
-## Vulcanize
+## Vulcanize {#vulcanize}
 
 The latest versions of the [`vulcanize`](https://github.com/Polymer/vulcanize) tool are updated for the new {{site.project_title}}
 element format. Newer versions of vulcanize are **not** backward compatible:

--- a/0.9/docs/release-notes.md
+++ b/0.9/docs/release-notes.md
@@ -161,9 +161,15 @@ The CSP-specific functions of [`vulcanize`](https://github.com/Polymer/vulcanize
 split into a separate utility, [`crisper`](https://github.com/PolymerLabs/crisper). To prepare a site for
 deployment in a CSP environment, you can use a command like this:
 
-    vulcanize --inline-scripts --inline-css target.html | crisper --html build.html --js build.js
+    vulcanize --inline-scripts --inline-css target.html | \
+        crisper --html build.html --js build.js
 
 For more details on the `vulcanize` arguments, see the [README](https://github.com/Polymer/vulcanize).
+
+**Note:** The latest versions of `vulcanize` are **not** compatible with {{site.project_title}} 0.5.
+For 0.5 projects, use `vulcanize` versions **earlier than 1.0**. `vulcanize` 0.7.10 is the latest version
+supporting 0.5 projects.
+{: .alert .alert-info }
 
 ### Utility functions
 


### PR DESCRIPTION
Fixes #1015.
Fixed missing semicolons in CSS mixin definitions (thanks @ragingwind)
Added note on vulcanize to migration guide & updated vulcanize notes in release notes.
Several formatting fixes.