### PR TITLE
fix mixins passed to @apply in layout attributes

### DIFF
--- a/1.0/docs/migration.md
+++ b/1.0/docs/migration.md
@@ -621,7 +621,8 @@ you'll need to make some changes:
 3.  Replace the layout attributes with custom properties, using `@apply` inside
     your element's CSS.
 
-        @apply(--layout-horizontal --layout-wrap);
+        @apply(--layout-horizontal);
+        @apply(--layout-wrap);
 
 Before:
 
@@ -660,7 +661,8 @@ After:
         
         .header {
           /* layout properties for a local DOM element */
-          @apply(--layout-horizontal --layout-center);
+          @apply(--layout-horizontal);
+          @apply(--layout-center);
         }
       </style>
       <template>


### PR DESCRIPTION
Since 0.9.1 that passing multiple mixins to @apply doesn't work. As mentioned in Polymer/polymer#1601 and PolymerElements/iron-flex-layout#15