### PR TITLE
Added use of {{index}} to template example

### DIFF
--- a/1.0/docs/devguide/templates.md
+++ b/1.0/docs/devguide/templates.md
@@ -38,6 +38,7 @@ Example:
 
         <div> Employee list: </div>
         <template is="dom-repeat" items="{{employees}}">
+            <div># <span>{{index}}</span></div>
             <div>First name: <span>{{item.first}}</span></div>
             <div>Last name: <span>{{item.last}}</span></div>
         </template>


### PR DESCRIPTION
Added use of {{index}} to template dom-repeat example, because it explained index but then didn't use it so it was confusing just how it could be used.