### PR TITLE
Track example with listeners still using annotated listener

### DIFF
--- a/1.0/docs/devguide/events.md
+++ b/1.0/docs/devguide/events.md
@@ -206,7 +206,7 @@ Example with `listeners`:
       </style>
 
       <template>
-        <div id="dragme" on-track="handleTrack">{{message}}</div>
+        <div id="dragme">{{message}}</div>
       </template>
 
       <script>
@@ -216,7 +216,7 @@ Example with `listeners`:
           is: 'drag-me',
 
           listeners: {
-            track: 'handleTrack'
+            track: 'dragme.handleTrack'
           },
 
           handleTrack: function(e) {


### PR DESCRIPTION
Isn't it supposed to show an example in which `on-track="handleTrack"` is not used?