### PR TITLE
Improve link to GitHub Issues from articles/index.html

### DIFF
--- a/0.5/articles/index.md
+++ b/0.5/articles/index.md
@@ -54,5 +54,5 @@ and <a href="https://plus.google.com/{{collaborator.gplus}}?rel=author" target="
 {% endfor %}
 
 <div style="margin-top:5em;">
-_Have an idea for an article? [Suggest it](https://github.com/Polymer/docs/issues/new)!_
+_Have an idea for an article? [Suggest it](https://github.com/Polymer/docs/issues/new?labels=article)!_
 </div>

--- a/1.0/articles/index.md
+++ b/1.0/articles/index.md
@@ -60,5 +60,5 @@ and <a href="https://plus.google.com/{{collaborator.gplus}}?rel=author" target="
 {% endfor %}
 
 <div style="margin-top:5em;">
-_Have an idea for an article? [Suggest it](https://github.com/Polymer/docs/issues/new)!_
+_Have an idea for an article? [Suggest it](https://github.com/Polymer/docs/issues/new?labels=article)!_
 </div>


### PR DESCRIPTION
Automatically apply 'articles' label when user clicks GitHub Issues link from articles/index.html.