### PR TITLE
Add a section about Polyup to the migration guide

### DIFF
--- a/1.0/docs/migration.md
+++ b/1.0/docs/migration.md
@@ -11,6 +11,16 @@ subtitle: About this release
 This guide describes the changes required to migrate a {{site.project_title}} 
 element from 0.5 to 1.0.  
 
+## Polyup 
+
+We have been working on a tool called `polyup` to automatically
+perform many of the changes detailed here. See an interactive demo 
+[here](http://polymerlabs.github.io/polyup/), and check out the list of current 
+and planned upgrades that it performs on its 
+[README at github](https://github.com/PolymerLabs/polyup#html).
+
+## Migration
+
 When migrating, the following items can be translated easily from 0.5 to 1.0:
 
 *   [Web components polyfill library](#polyfill)

--- a/1.0/docs/migration.md
+++ b/1.0/docs/migration.md
@@ -11,10 +11,10 @@ subtitle: About this release
 This guide describes the changes required to migrate a {{site.project_title}} 
 element from 0.5 to 1.0.  
 
-## Polyup 
+## Polyup Tool
 
 We have been working on a tool called `polyup` to automatically
-perform many of the changes detailed here. See an interactive demo 
+perform many of the changes detailed in this guide. See an interactive demo 
 [here](http://polymerlabs.github.io/polyup/), and check out the list of current 
 and planned upgrades that it performs on its 
 [README at github](https://github.com/PolymerLabs/polyup#html).


### PR DESCRIPTION
I wasn't sure where to put it. I went with prominent placement at the top of the page to catch people who visit the page frequently and would likely otherwise miss it.