### PR TITLE
Limit search to polymer 1.0 docs

### DIFF
--- a/1.0/elements/app-bar.html
+++ b/1.0/elements/app-bar.html
@@ -71,7 +71,7 @@
         if (e.keyCode == 13) { // Enter
           if (sender.value) {
             recordSearch(sender.value);
-            var q = 'site:polymer-project.org+' + sender.value;
+            var q = 'site:polymer-project.org/1.0+' + sender.value;
             window.open('https://www.google.com/search?q=' + q);
           }
         }


### PR DESCRIPTION
When searching from within 1.0 docs, I should only see results for Polymer 1.0. This can be done using `site:polymer-project.org/1.0` in the google search query.