### PR TITLE
devguide/properties: Fix 'until once' wording (random typo)

### DIFF
--- a/1.0/docs/devguide/properties.md
+++ b/1.0/docs/devguide/properties.md
@@ -317,7 +317,7 @@ array.
 
 These observers differ from single-property observers in a few ways:
 
-*   Observers are not invoked until once all dependent properties are defined (`!== undefined`).  
+*   Observers are not invoked until all dependent properties are defined (`!== undefined`).  
     So each dependent properties should have a default `value` defined in `properties` (or otherwise 
     be initialized to a non-`undefined` value) to ensure the observer is called.
 *   Observers do not receive `old` values as arguments, only new values.  Only single-property 
@@ -624,7 +624,7 @@ The function is provided as a string with dependent properties as arguments
 in parenthesis. The function will be called once for any change to 
 the dependent properties.
 
-The computing function is not invoked until once **all** dependent properties 
+The computing function is not invoked until **all** dependent properties 
 are defined (`!== undefined`). So each dependent properties should have a 
 default `value` defined in `properties` (or otherwise be initialized to a 
 non-`undefined` value) to ensure the property is computed.


### PR DESCRIPTION
Should be either:

1. [...] are not invoked until all [...]
2. [...] are only invoked once all [...]

This change does (1).