### PR TITLE
removed feature-carousel, not used in 1.0

### DIFF
--- a/1.0/elements/homepage_elements.html
+++ b/1.0/elements/homepage_elements.html
@@ -26,7 +26,6 @@ following command:
 
 <!-- homepage -->
 <link rel="import" href="learn-tabs.html">
-<link rel="import" href="feature-carousel.html">
 
 <link rel="import" href="../components/paper-button/paper-button.html">
 <link rel="import" href="../components/paper-dialog/paper-dialog.html">


### PR DESCRIPTION
this one is in the 1.0 folder (which I assume means it's getting built into the 1.0 part of the site). The 0.5 folder has its own copy of feature-carousel.