### PR TITLE
Added documentation for Custom Events / `this.fire()`

### DIFF
--- a/1.0/docs/devguide/events.md
+++ b/1.0/docs/devguide/events.md
@@ -104,7 +104,7 @@ _not_ `core-signal-newData`. To avoid confusion, always use lowercase event name
 
 ## Custom Events {#custom-events}
 
-To fire a custom event from the host element use `this.fire()`. You can also pass in data to event handlers as an argument to `this.fire()`.
+To fire a custom event from the host element use the `fire` method. You can also pass in data to event handlers as an argument to `fire`.
 
 Example:
 
@@ -120,8 +120,8 @@ Example:
 
           is: 'x-custom',
 
-          handleClick: function() {
-            this.fire('kick', { kicked: true })
+          handleClick: function(e, detail) {
+            this.fire('kick', {kicked: true});
           }
 
         });
@@ -130,11 +130,11 @@ Example:
 
     </dom-module>
     
-    <x-custom> </x-custom>
+    <x-custom></x-custom>
     
     <script>
-        document.querySelector('x-custom').addEventListener('kick', function (e){
-            console.log (e.kicked); //Prints true
+        document.querySelector('x-custom').addEventListener('kick', function (e) {
+            console.log(e.detail.kicked); // true
         })
     </script>
 

--- a/1.0/docs/devguide/events.md
+++ b/1.0/docs/devguide/events.md
@@ -102,6 +102,41 @@ So the attribute `on-core-signal-newData` sets up a listener for `core-signal-ne
 _not_ `core-signal-newData`. To avoid confusion, always use lowercase event names.
 {: .alert .alert-info } 
 
+## Custom Events {#custom-events}
+
+To fire a custom event from the host element use `this.fire()`. You can also pass in data to event handlers as an argument to `this.fire()`.
+
+Example:
+
+    <dom-module id="x-custom">
+
+      <template>
+        <button on-click="handleClick">Kick Me</button>
+      </template>
+
+      <script>
+
+        Polymer({
+
+          is: 'x-custom',
+
+          handleClick: function() {
+            this.fire('kick', { kicked: true })
+          }
+
+        });
+
+      </script>
+
+    </dom-module>
+    
+    <x-custom> </x-custom>
+    
+    <script>
+        document.querySelector('x-custom').addEventListener('kick', function (e){
+            console.log (e.kicked); //Prints true
+        })
+    </script>
 
 ## Gesture events {#gestures}
 


### PR DESCRIPTION
There seems to be no documentation for custom events which was there in 0.5. Initial text, with style conventions of Polymer. Pl update if required.

Seems more people are confused, like me -> http://stackoverflow.com/questions/30544290/polymer-1-0-custom-events