### PR TITLE
Fix for automatic node finding example

### DIFF
--- a/1.0/docs/devguide/local-dom.md
+++ b/1.0/docs/devguide/local-dom.md
@@ -90,7 +90,7 @@ Example:
           is: 'x-custom',
 
           ready: function() {
-            this.$.name.textContent = this.name;
+            this.$.name.textContent = this.tagName;
           }
 
         });


### PR DESCRIPTION
The example was using this.name (which was undefined for me) so it didn't have any effect.
I changed this to this.tagName so it will display 'x-custom'.  I think this was the intent.