### PR TITLE
fix doc-merge task. Close Gh-1476

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -152,29 +152,8 @@ module.exports = function(grunt) {
     grunt.task.run('vulcanize');
   });
 
-  grunt.task.registerTask('doc-merge-all', 'Doc merge all element sets', function() {
-
-    var docMerge = grunt.config.get('doc_merge') || {};
-
-    // Exclude 0.5 because it's hardcoded in task.
-    POLYMER_VERSIONS.slice(1).forEach(function(ver) {
-      // Replace version 0.5 with 0_5 because the _data folder
-      // can't have directories with dots in their name
-      var verUnderscore = ver.replace('.', '_');
-
-      docMerge[verUnderscore] = {
-        src: ver + '/components',
-        dest: '_data/versions/' + verUnderscore + '/elements'
-      };
-      docMerge[verUnderscore].options = docMerge['0_5'].options;
-    });
-
-    grunt.config.set('doc_merge', docMerge);
-    grunt.task.run('doc_merge');
-  });
-
   // Task to run vulcanize and build the jekyll site
-  grunt.registerTask('docs', ['doc-merge-all', 'vulcanize-elements', 'jekyll:build']);
+  grunt.registerTask('docs', ['doc_merge', 'vulcanize-elements', 'jekyll:build']);
 
   // Task just for running the GAE dev server.
   grunt.registerTask('serve', ['appengine:run:frontend']);


### PR DESCRIPTION
The doc merge task was previously being run for all polymer versions. It should now only run for 0.5. I still wasn't able to reproduce the error you were seeing but I *think* this may be the fix. You'll need to delete your `_data/versions` directory so it no longer has a `1_0` dir in it.

@arthurevans @kaycebasques PTAL