### PR TITLE
Add note about escaping in shells

### DIFF
--- a/1.0/docs/start/getting-the-code.md
+++ b/1.0/docs/start/getting-the-code.md
@@ -55,6 +55,10 @@ The next step is to install {{site.project_title}}:
 
     bower install --save Polymer/polymer#^1.2.0
 
+Depending on your shell, `Polymer/polymer#^1.2.0` may need to be escaped appropriately.
+If you get an error somewhere around the lines of 'match not found', try surrounding 
+it with single or double quotes.
+
 Bower adds a `bower_components/` folder in the root of your project and
 fills it with {{site.project_title}} and its dependencies.
 


### PR DESCRIPTION
When I ran the install command in `zsh`, it reported `zsh: no matches found: Polymer/polymer#^1.2.0`. So I added a small note.