### PR TITLE
Update docs to use compound bindings

### DIFF
--- a/1.0/docs/devguide/data-binding.md
+++ b/1.0/docs/devguide/data-binding.md
@@ -68,8 +68,8 @@ annotation inside the child element.
     <dom-module id="user-view">
 
         <template>   
-          First: <span>{{firstName}}</span><br>
-          Last: <span>{{lastName}}</span>
+          First: {{firstName}}<br>
+          Last: {{lastName}}
         </template>
 
         <script>


### PR DESCRIPTION
Atom editor removed spaces before new lines.
The only relevant changes are lines 71, 72.