### PR TITLE
Add note on extending elements with Shadow DOM

### DIFF
--- a/1.0/docs/devguide/registering-elements.md
+++ b/1.0/docs/devguide/registering-elements.md
@@ -91,16 +91,16 @@ Two notes about the custom constructor:
 
 ### Extend native HTML elements {#type-extension}
 
+Polymer currently only supports extending native HTML elements (for example,
+`input`, or `button`, as opposed to extending other custom elements, which will
+be supported in a future release). These native element extensions are called
+_type extension custom elements_.
+
 **Note:** When using Shadow DOM, extension of native elements can have
 unexpected behavior and is sometimes not permitted. It is suggested that
 you test your element with Shadow DOM enabled to catch any problems
 during development.
 {: .alert .alert-info }
-
-Polymer currently only supports extending native HTML elements (for example,
-`input`, or `button`, as opposed to extending other custom elements, which will
-be supported in a future release). These native element extensions are called
-_type extension custom elements_.
 
 To extend a native HTML element, set the `extends` property on your prototype to 
 the tag name of the element to extend.

--- a/1.0/docs/devguide/registering-elements.md
+++ b/1.0/docs/devguide/registering-elements.md
@@ -91,6 +91,12 @@ Two notes about the custom constructor:
 
 ### Extend native HTML elements {#type-extension}
 
+**Note:** When using Shadow DOM, extension of native elements can have
+unexpected behavior and is sometimes not permitted. It is suggested that
+you test your element with Shadow DOM enabled to catch any problems
+during development.
+{: .alert .alert-info }
+
 Polymer currently only supports extending native HTML elements (for example,
 `input`, or `button`, as opposed to extending other custom elements, which will
 be supported in a future release). These native element extensions are called

--- a/1.0/docs/devguide/registering-elements.md
+++ b/1.0/docs/devguide/registering-elements.md
@@ -96,10 +96,11 @@ Polymer currently only supports extending native HTML elements (for example,
 be supported in a future release). These native element extensions are called
 _type extension custom elements_.
 
-**Note:** When using Shadow DOM, extension of native elements can have
-unexpected behavior and is sometimes not permitted. It is suggested that
-you test your element with Shadow DOM enabled to catch any problems
-during development.
+**Note:** When using native shadow DOM, extension of native elements can have
+unexpected behavior and is sometimes not permitted. Test your element with
+native shadow DOM enabled to catch any problems during development.
+For information on enabling native shadow DOM, see
+[Global Polymer settings](https://www.polymer-project.org/1.0/docs/devguide/settings.html).
 {: .alert .alert-info }
 
 To extend a native HTML element, set the `extends` property on your prototype to 


### PR DESCRIPTION
Sometimes it’s simply not permitted depending on the platform.

@cdata 