### PR TITLE
Remove legacy reference to python webserver

### DIFF
--- a/1.0/docs/start/reusableelements.md
+++ b/1.0/docs/start/reusableelements.md
@@ -70,10 +70,7 @@ the paths as if the component folders were siblings to your `test-element` folde
 
     <link rel="import" href="../paper-button/paper-button.html">
 
-A good way to quickly sanity
-test your component is to access your demo file using polyserve. There are several ways to do this
-but one easy method is to run a simple web server that ships with Python, using the following
-commands:
+A good way to quickly sanity test your component is to access your demo file using polyserve:
 
     $ polyserve
     Starting Polyserve on port 8080


### PR DESCRIPTION
The "creating reusable elements" section of the "Get started" docs contain a reference to the python web server which seems to be a legacy from the pre-polyserve days and is confusing because the example doesn't actually use python but polyserve...