### PR TITLE
Update styling.md

### DIFF
--- a/1.0/docs/devguide/styling.md
+++ b/1.0/docs/devguide/styling.md
@@ -87,7 +87,7 @@ This implies:
           <template>
 
             <style>
-              .content-wrapper > ::content .special {
+              .content-wrapper ::content > .special {
                 background: orange;
               }
             </style>


### PR DESCRIPTION
With the > on the left of ::content, the > will be removed -- is that the intent?  I could easily be wrong here, but I'm wondering if the > should go to the right of the ::content.
