### PR TITLE
fix prop change event docs, fixes #1437

### DIFF
--- a/1.0/docs/devguide/data-binding.md
+++ b/1.0/docs/devguide/data-binding.md
@@ -268,13 +268,13 @@ When you configure a declared property with the `notify` flag set to `true`,
     `this.firstName` will fire `first-name-changed`. Listeners will receive an event object 
     whose `e.detail.value` attribute has the changing property's new value.
 
-When using a {{site.project_title}} element with other elements or frameworks, you can 
-manually attach an <code>on-<var>property</var>-changed</code> listener to an element to
-be notified of property changes, and take the necessary actions based on the new value. 
+You can manually attach a <code><var>property</var>-changed</code> 
+listener to an element to [notify external elements, frameworks,
+or libraries](/1.0/docs/devguide/properties.html#notify-external) of property 
+changes.
 
-This is essentially what {{site.project_title}} does when you create a two-way data
-binding.
-
+This is essentially what {{site.project_title}} does when you create a 
+two-way data binding.
 
 ### Two-way binding to native elements {#two-way-native}
 

--- a/1.0/docs/devguide/properties.md
+++ b/1.0/docs/devguide/properties.md
@@ -615,14 +615,22 @@ Example:
 
 ## Property change notification events (notify) {#notify}
 
-When a property is set to `notify: true`, an event,
-<code><var>property-name</var>-changed</code>, is fired whenever the property
-value changes. These events are used by the two-way data binding system, and can
-also notify external scripts and frameworks to respond to changes in the element.
+When a property is set to `notify: true`, an event is fired whenever the 
+property value changes. The event name is:
 
-For more on property change notifications and data binding, see  [Property
-change notification and two-way binding](data-binding.html#property-notification).
+<code><var>property-name</var>-changed</code>
 
+Where <code><var>property-name</var></code> is the dash-case version of 
+the property name. For example, a change to `this.firstName` fires 
+`first-name-changed`. 
+
+These events are used by the two-way data binding system. External 
+scripts can also listen for events (such as `first-name-changed`) 
+directly using `addEventListener`.
+
+For more on property change notifications and data binding, see 
+[Property change notification and two-way 
+binding](data-binding.html#property-notification).
 
 ## Read-only properties {#read-only}
 


### PR DESCRIPTION
it looks like the documentation error was already fixed (docs said that `propName-changed` event was fired when it should have said `prop-name-changed`) but I added an example for clarity. 