### PR TITLE
Update events.md to have event retargeting code example

### DIFF
--- a/1.0/docs/devguide/events.md
+++ b/1.0/docs/devguide/events.md
@@ -323,3 +323,38 @@ normalized event has the following properties:
     (equivalent to `event.path` under shadow DOM).
 
 
+Example:
+    <dom-module id="event-retargeting">
+      <template>
+        <button id="myButton">Click Me</button>
+      </template>
+    </dom-module>
+
+    <script>
+
+      Polymer({
+
+          is: 'event-retargeting',
+
+          listeners: {
+            'myButton.click': 'handleTap',
+          },
+
+          handleTap(e) {
+            console.info(e.target.id + ' was tapped.');
+          }
+
+        });
+
+    </script>
+
+  </dom-module>
+
+  <script>
+    document.querySelector('event-retargeting').addEventListener('click', function(){
+      var normalizedEventObject = Polymer.dom(event);
+      console.info('rootTarget is:', normalizedEventObject.rootTarget); // logs #myButton
+      console.info('localTarget is:', normalizedEventObject.localTarget); // logs an instance of event-targeting
+      console.info('path is:', normalizedEventObject.path); // logs [#myButton, document-fragment, event-retargeting, body, html, document, Window]
+    });
+  </script>

--- a/1.0/docs/devguide/events.md
+++ b/1.0/docs/devguide/events.md
@@ -337,24 +337,26 @@ Example:
           is: 'event-retargeting',
 
           listeners: {
-            'myButton.click': 'handleTap',
+            'myButton.click': 'handleClick',
           },
 
-          handleTap(e) {
-            console.info(e.target.id + ' was tapped.');
+          handleClick(e) {
+            console.info(e.target.id + ' was clicked.');
           }
 
         });
 
     </script>
 
-  </dom-module>
+    </dom-module>
 
-  <script>
-    document.querySelector('event-retargeting').addEventListener('click', function(){
-      var normalizedEventObject = Polymer.dom(event);
-      console.info('rootTarget is:', normalizedEventObject.rootTarget); // logs #myButton
-      console.info('localTarget is:', normalizedEventObject.localTarget); // logs an instance of event-targeting
-      console.info('path is:', normalizedEventObject.path); // logs [#myButton, document-fragment, event-retargeting, body, html, document, Window]
-    });
-  </script>
+    <event-retargeting></event-retargeting>
+
+    <script>
+      document.querySelector('event-retargeting').addEventListener('click', function(){
+        var normalizedEventObject = Polymer.dom(event);
+        console.info('rootTarget is:', normalizedEventObject.rootTarget); // logs #myButton
+        console.info('localTarget is:', normalizedEventObject.localTarget); // logs an instance of event-targeting that was originally queried
+        console.info('path is:', normalizedEventObject.path); // logs [#myButton, document-fragment, event-retargeting, body, html, document, Window]
+      });
+    </script>


### PR DESCRIPTION
## PR Goals
- [x] Add an explicit example of event-re-targeting in Polymer to be more consistent in the document flow of `events.md` regarding Polymer-specific handling of behavior of this aspect of Shadow DOM polyfilled by Shady DOM
- [x] Write a forced re-targeting situation after discussing this with @sjmiles; likely with the `click`event to be simple.

## Side-effects
- A slightly longer events.md file