### PR TITLE
Fix fullbleed example in 1.0 migration guide #1610

### DIFF
--- a/1.0/docs/migration.md
+++ b/1.0/docs/migration.md
@@ -796,7 +796,7 @@ Example of using the layout classes in the main page:
       <!-- import module -->
       <link rel="import" href="/bower_components/iron-flex-layout/iron-flex-layout-classes.html">
       <!-- include the necessary style modules -->
-      <style is="custom-style" include="iron-flex iron-flex-alignment"></style>
+      <style is="custom-style" include="iron-flex iron-positioning"></style>
     </head>
     <body class="fullbleed layout horizontal center-center">
      ...


### PR DESCRIPTION
The [migration guide's example](https://github.com/Polymer/docs/commit/f73b1a88a28491f6c64304fd3c9a823356cf1d9e?diff=unified#diff-40fb74a27ef06c86d2f8816e0f9a0a6bR799) used the `fullbleed` class but did not include the `iron-positioning` style module, where the class is defined. The example included `iron-flex-alignment` possibly for the `center-center` class, which was already defined in `iron-flex` and thus redundant in this case.

This patch replaces `iron-flex-alignment` with `iron-positioning` in the example.