### PR TITLE
Minor doc update

### DIFF
--- a/1.0/docs/devguide/events.md
+++ b/1.0/docs/devguide/events.md
@@ -335,7 +335,7 @@ Example:
 
     <script>
       var el = document.querySelector('event-retargeting');
-      el.addEventListener('click', function(){
+      el.addEventListener('click', function(event){
         var normalizedEvent = Polymer.dom(event);
         // logs #myButton
         console.info('rootTarget is:', normalizedEvent.rootTarget);


### PR DESCRIPTION
This commit addresses https://github.com/Polymer/polymer/issues/3613

**Larger explanation**: Chrome provides a global event during event
listeners, so the docs example would still work for Chrome... but
Firefox would end up breaking (since no global event is provided).