### PR TITLE
Add note about bower and gulp dependency

### DIFF
--- a/app/1.0/start/toolbox/set-up.md
+++ b/app/1.0/start/toolbox/set-up.md
@@ -16,7 +16,7 @@ App Toolbox template in less than 15 minutes.
 1.  Install the LTS version (4.x) of Node.js. The current version (6.x) should work, but is not
     officially supported. Versions below LTS are not supported.
 
-1. If you don't have them installed, install bower and gulp
+1. If you don't have bower installed, install it
 
         npm install -g bower
 

--- a/app/1.0/start/toolbox/set-up.md
+++ b/app/1.0/start/toolbox/set-up.md
@@ -16,6 +16,10 @@ App Toolbox template in less than 15 minutes.
 1.  Install the LTS version (4.x) of Node.js. The current version (6.x) should work, but is not
     officially supported. Versions below LTS are not supported.
 
+1. If you don't have them installed, install bower and gulp
+
+        npm install -g bower
+
 1.  Install the Polymer CLI
 
         npm install -g polymer-cli


### PR DESCRIPTION
Installing from a clean slate, `polymer init <blah>` fails silently without bower (and gulp is needed in there somewhere).  Thus I suggest adding a note about requiring the use of bower and gulp.
