### PR TITLE
Moving style block to <dom-module>

### DIFF
--- a/app/1.0/docs/devguide/feature-overview.md
+++ b/app/1.0/docs/devguide/feature-overview.md
@@ -17,12 +17,13 @@ A basic Polymer element definition looks like this:
 
 ```
     <dom-module id="element-name">
-
+      
+      <style>
+        /* CSS rules for your element */
+      </style>
+      
       <template>
-        <style>
-          /* CSS rules for your element */
-        </style>
-
+      
         <!-- local DOM for your element -->
 
         <div>{{greeting}}</div> <!-- data bindings in local DOM -->


### PR DESCRIPTION
Following the recommendation at https://www.polymer-project.org/1.0/docs/devguide/styling, moving the <style> block from within <template> to <dom-module>