### PR TITLE
Last step of element tutorial directs to wrong place

### DIFF
--- a/app/1.0/start/first-element/step-5.md
+++ b/app/1.0/start/first-element/step-5.md
@@ -168,8 +168,8 @@ elements on the page:
 Ready to get started on your own element? You can use the Polymer CLI to
 [Create an element project](/1.0/docs/tools/polymer-cli#element).
 
-You can also see the [Build an app](/1.0/start/psk/set-up)
-tutorial to get started on an app using the Polymer Starter Kit.
+You can also see the [Build an app](/1.0/start/toolbox/set-up)
+tutorial to get started on an app using the Polymer App Toolbox.
 
 Or review the previous section:
 


### PR DESCRIPTION
Old PSK tutorial points to PSK tutorial instead of App Toolbox one.