### PR TITLE
Looks like a typo on emphasis

### DIFF
--- a/app/1.0/docs/devguide/data-system.md
+++ b/app/1.0/docs/devguide/data-system.md
@@ -99,7 +99,7 @@ In summary:
 An *observable change* is **a data change that Polymer can associate with a path**. Certain changes
 are automatically *observable*:
 
-*   Setting a *direct property *of the element.
+*   Setting a *direct property* of the element.
 
    `this.owner = 'Jane';`
 


### PR DESCRIPTION
With a space before the asterisk, md will print both asterisks rather than put emphasis on the text.