### PR TITLE
Use playlist instead of individual videos

### DIFF
--- a/app/1.0/start/index.html
+++ b/app/1.0/start/index.html
@@ -116,8 +116,13 @@
   <div class="subsection">
     <h2>Watch the Polycasts</h2>
     <div class="section-columns example-code">
-      <div class="example-code flex iframe-wrapper">
-        <iframe src="https://www.youtube.com/embed/594LXGtorYE?list=PLOU2XLYxmsII5c3Mgw6fNYCzaWrsM3sMN" frameborder="0" allowfullscreen></iframe>
+      <div class="example-code flex">
+        <google-youtube video-id="videoseries"
+          list-type="playlist"
+          list="PLNYkxOF6rcIDdS7HWIC_BYRunV6MHs5xo"
+          autoplay="0"
+          rel="0">
+          </google-youtube>
       </div>
       <div>
         <p>Ready to get your hands dirty and revolutionize the modern web? Join Rob Dodson from the Chrome Developer Relations team as he explores the ins and outs of Polymer, a new library that's pushing the boundaries of what's possible in the browser. Learn about the basic building blocks that make up a Polymer application, and see how to compose those elements into buttery smooth mobile experiences. The future of front end development is all here, on the Polycasts playlist!</p>


### PR DESCRIPTION
Instead of using an individual video this now pulls in the latest video from the playlist. This same setup is used in /1.0/blog/ and it means we don't have to manually update the video id each time a new episode rolls out


@notwaldorf @arthurevans PTAL