### PR TITLE
Fix blog titles

### DIFF
--- a/app/sass/_main.scss
+++ b/app/sass/_main.scss
@@ -184,6 +184,7 @@ section {
   & > p:not(:last-child),
   & > h2:not(:last-child) {
     margin-right: $medium-padding;
+    overflow: hidden;
 
     @media (max-width: $mobile-media-breakpoint) {
       margin-right: 0px;
@@ -205,6 +206,9 @@ h2 {
 
   &.underline {
     border-bottom: 1px solid $pink-a400;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   }
 }
 

--- a/templates/base-blog.html
+++ b/templates/base-blog.html
@@ -145,7 +145,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div class="section-columns">
         {% for item in articles[:3] %}
         <div>
-          <h2 class="underline">{{{item.title}}}</h2>
+          <h2 class="underline" title="{{{item.title}}}">{{{item.title}}}</h2>
           <p>{{{item.description}}}</p>
           <a href="{{{item.path}}}.html" class="blue-button">Read more</a>
         </div>


### PR DESCRIPTION
R: @robdodson 

For you buddy. Mousing over the titles shows the full title as alt/title text.

![screen shot 2016-08-24 at 10 52 50 am](https://cloud.githubusercontent.com/assets/238208/17941599/ec6d29c4-69e8-11e6-8fea-45d1f0ea3cc2.png)
