### PR TITLE
example for "Shared styles..." don't use class red

### DIFF
--- a/app/1.0/docs/devguide/styling.md
+++ b/app/1.0/docs/devguide/styling.md
@@ -633,7 +633,9 @@ To use a style module in an element:
     <!-- include the style module by name -->
     <style include="shared-styles"></style>
     <style>:host { display: block; }</style>
-    Hi
+    <div class="red">
+      Hi
+    </div>
   </template>
   <script>Polymer({is: 'x-foo'});</script>
 </dom-module>


### PR DESCRIPTION
The example for "Shared styles and external stylesheets" don't use the shared style class "red".
