### PR TITLE
Fix 1753

### DIFF
--- a/app/1.0/blog/2016-09-09-polymer-2.0.md
+++ b/app/1.0/blog/2016-09-09-polymer-2.0.md
@@ -92,4 +92,4 @@ For more detailed documentation on the `2.0` branch as it evolves, see the [READ
 
 Over the next couple months, we’ll be continuing to iterate on the API. We’ll also be upgrading the [elements built by the Polymer team](https://elements.polymer-project.org) to be built on top of 2.0.
 
-We'll also be talking a bunch more about Polymer 2.0 at the upcoming [Polymer Summit](https://www.polymer-project.org/summit). Looking forward to hearing what you think!
+We'll also be talking a bunch more about Polymer 2.0 at the upcoming <a href="/summit/" target="_blank">Polymer Summit</a>. Looking forward to hearing what you think!


### PR DESCRIPTION
Edited link to add trailing slash and force new window to open. 

To test:

1. Go to https://www.polymer-project.org/1.0/blog/2016-09-09-polymer-2.0.
2. Scroll down to the bottom of the page.
3. Click the link in the final paragraph to the Polymer Summit page.

No error should appear, and a new window should open with the Summit page (https://www.polymer-project.org/summit).