### PR TITLE
Replace wrong 'polymer init' template. Fixes #1783

### DIFF
--- a/app/1.0/start/toolbox/set-up.md
+++ b/app/1.0/start/toolbox/set-up.md
@@ -56,7 +56,7 @@ topics.
 
 1. Initialize your project.
 
-        polymer init app-drawer-template
+        polymer init starter-kit
 
 ## Serve your project
 


### PR DESCRIPTION
Since `app-drawer-template` was moved, this needs to be replaced.