### PR TITLE
Replace oversight tag content

### DIFF
--- a/app/2.0/docs/upgrade.md
+++ b/app/2.0/docs/upgrade.md
@@ -112,8 +112,8 @@ Before {.caption}
     </h2>
     <div>
       <content></content>
-        </div>
-    </template>
+    </div>
+  </template>
 </dom-module>
 
   ...
@@ -137,7 +137,7 @@ After {.caption}
       <slot name="title"></slot>
     </h2>
     <div>
-      <content></content>
+      <slot></slot>
     </div>
   </template>
 </dom-module>


### PR DESCRIPTION
This commit replaces the "content" tag in the part "Afer" under the
section "DOM Template" of the upgrade guide by a "slot" tag.

Closes #1807