### PR TITLE
Added set method to list of polymer mutator functions

### DIFF
--- a/app/1.0/docs/devguide/model-data.md
+++ b/app/1.0/docs/devguide/model-data.md
@@ -150,6 +150,7 @@ Every Polymer element has the following array mutation methods available:
 *   <code>push(<var>path</var>, <var>item1</var>, [..., <var>itemN</var>])</code>
 *   <code>pop(<var>path</var>)</code>
 *   <code>unshift(<var>path</var>, <var>item1</var>, [..., <var>itemN</var>])</code>
+*   <code>set(<var>path</var>, <var>item</var>)</code>
 *   <code>shift(<var>path</var>)</code>
 *   <code>splice(<var>path</var>, <var>index</var>, <var>removeCount</var>, [<var>item1</var>,
     ..., <var>itemN</var>])</code>

--- a/app/2.0/docs/devguide/model-data.md
+++ b/app/2.0/docs/devguide/model-data.md
@@ -150,6 +150,7 @@ Every Polymer element has the following array mutation methods available:
 *   <code>push(<var>path</var>, <var>item1</var>, [..., <var>itemN</var>])</code>
 *   <code>pop(<var>path</var>)</code>
 *   <code>unshift(<var>path</var>, <var>item1</var>, [..., <var>itemN</var>])</code>
+*   <code>set(<var>path</var>,<var>item</var>)</code>
 *   <code>shift(<var>path</var>)</code>
 *   <code>splice(<var>path</var>, <var>index</var>, <var>removeCount</var>, [<var>item1</var>,
     ..., <var>itemN</var>])</code>


### PR DESCRIPTION
Looks like the docs forgot the set method. This might seem superfluous but it confused me for a little while.