### PR TITLE
fix firebase hosting glob notation

### DIFF
--- a/app/1.0/start/toolbox/deploy.md
+++ b/app/1.0/start/toolbox/deploy.md
@@ -139,7 +139,7 @@ guide](https://www.firebase.com/docs/hosting/quickstart.html).
 
     ```
     "rewrites": [ {
-      "source": "**/!{*.*}",
+      "source": "**",
       "destination": "/index.html"
     } ]
     ```

--- a/app/2.0/start/toolbox/deploy.md
+++ b/app/2.0/start/toolbox/deploy.md
@@ -132,7 +132,7 @@ guide](https://www.firebase.com/docs/hosting/quickstart.html).
 
     ```
     "rewrites": [ {
-      "source": "**/!{*.*}",
+      "source": "**",
       "destination": "/index.html"
     } ]
     ```


### PR DESCRIPTION
I think this glob notation is wrong. It does not work for me. 
Maybe an old version?