### PR TITLE
Fix typo in new format for custom-styles (2.0)

### DIFF
--- a/app/2.0/docs/upgrade.md
+++ b/app/2.0/docs/upgrade.md
@@ -484,7 +484,7 @@ Before {.caption}
 
 
 ```html
-<style is="custom-style>
+<style is="custom-style">
   :root {
     --my-theme-color: #9C27B0;
   }
@@ -497,7 +497,7 @@ Before {.caption}
 
 ```html
 <custom-style>
-  <style is="custom-style>
+  <style is="custom-style">
     html {
       --my-theme-color: #9C27B0;
     }


### PR DESCRIPTION
A typo rendered the new format for custom-styles incorrectly