### PR TITLE
AppLocalizationBehavior > AppLocalizeBehavior typo

### DIFF
--- a/app/1.0/toolbox/localize.md
+++ b/app/1.0/toolbox/localize.md
@@ -70,5 +70,5 @@ Sample application loading resources from an external file. { .caption.}
 The main app is also responsible for loading the `Intl` polyfill
 (not shown above).
 
-Each element that needs to localize messages should also add the `Polymer.AppLocalizationBehavior`
+Each element that needs to localize messages should also add the `Polymer.AppLocalizeBehavior`
 and use the `localize` method to translate strings, as shown above.


### PR DESCRIPTION
via slack "srijken: Documentation question: https://www.polymer-project.org/1.0/toolbox/localize talks about both Polymer.AppLocalizationBehavior and Polymer.AppLocalizeBehavior. I can’t find the former.. is this a typo / old documentation or something?"