### PR TITLE
[BUGFIX] Use _boundHandler in slotchange example

### DIFF
--- a/app/2.0/docs/upgrade.md
+++ b/app/2.0/docs/upgrade.md
@@ -704,9 +704,14 @@ listener doesn't fire for the *initial* distribution.
 
 ```
 ready: function() {
+  // super.ready(); // if in a 2.0 only system
   var this._boundHandler = this._processLightChildren.bind(this);
-  setTimeout(this._processLightChildren);
+  setTimeout(this._boundHandler);
   this.$.slot.addEventListener('slotchange', this._processLightChildren);
+}
+
+_processLightChildren: function() {
+  console.log(this.$.slotmobileimage.assignedNodes());
 }
 ```
 

--- a/app/2.0/docs/upgrade.md
+++ b/app/2.0/docs/upgrade.md
@@ -704,14 +704,14 @@ listener doesn't fire for the *initial* distribution.
 
 ```
 ready: function() {
-  // super.ready(); // if in a 2.0 only system
+  // super.ready(); // for 2.0 class-based elements only
   var this._boundHandler = this._processLightChildren.bind(this);
   setTimeout(this._boundHandler);
   this.$.slot.addEventListener('slotchange', this._processLightChildren);
 }
 
 _processLightChildren: function() {
-  console.log(this.$.slotmobileimage.assignedNodes());
+  console.log(this.$.slot.assignedNodes());
 }
 ```
 


### PR DESCRIPTION
Furthermore

"You can use a `slotchange` event listener to react to runtime changes to distribution, but the event
listener doesn't fire for the *initial* distribution."

In Firefox it also fires for the *initial* distribution so it will be called two times using the above example...