### PR TITLE
Fix typo in 2.0/docs/upgrade

### DIFF
--- a/app/2.0/docs/upgrade.md
+++ b/app/2.0/docs/upgrade.md
@@ -964,8 +964,8 @@ Below are the general steps for defining a custom element using this new syntax:
 
 
     ```
-    // set tab-index if it's not already set
-    _ensureAttribute('tab-index', 0);
+    // set tabindex if it's not already set
+    _ensureAttribute('tabindex', 0);
     ```
 
 


### PR DESCRIPTION
Change `tab-index` to proper `tabindex` in case of copy/paste when looking how to upgrade from `hostAttributes`.

Not sure if this should be against master or a 2.0 branch, so leaving this here for now.