### PR TITLE
<dom-module> must set the "id" property instead of "is"

### DIFF
--- a/app/2.0/docs/upgrade.md
+++ b/app/2.0/docs/upgrade.md
@@ -802,7 +802,7 @@ Example: importing CSS mixin shim to an element {.caption}
 <!-- import Polymer.Element -->
 <link rel="import" href="../polymer/polymer-element.html">
 
-<dom-module is="x-custom">
+<dom-module id="x-custom">
   <template>
     <style>
       :host {


### PR DESCRIPTION
This is a Polymer 2.0 example. Use "id" instead of "is".