### PR TITLE
Add backticks to "is" for better clarity

### DIFF
--- a/app/2.0/docs/devguide/custom-elements.md
+++ b/app/2.0/docs/devguide/custom-elements.md
@@ -230,7 +230,7 @@ Elements have a *custom element state* that takes one of the following values:
 *   "uncustomized". The element does not have a valid custom element name. It is either a built-in
     element (`<p>`, `<input>`) or an unknown element that cannot become a custom element
     (`<nonsense>`)
-*   "undefined". The element is has a valid custom element name (such as "my-element"), but has not
+*   "undefined". The element `is` has a valid custom element name (such as "my-element"), but has not
     been defined.
 *   "custom". The element has a valid custom element name and has been defined and upgraded.
 *   "failed". An attempt to upgrade the element failed (for example, because the class was invalid).


### PR DESCRIPTION
Add backticks to "is" to make clearer that "is" refers to a property (eg. `MyElement.is`), and is not just a grammatical error.

Prevent confusion such as in #1948.