### PR TITLE
add a <noscript> fallback option

### DIFF
--- a/app/404.html
+++ b/app/404.html
@@ -14,6 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 {% include 'templates/head-meta.html' %}
 </head>
 <body class="fullbleed" unresolved>
+  {% include 'templates/noscript.html' %}
   <pw-shell>
     {% include 'templates/site-nav.html' %}
 

--- a/app/500.html
+++ b/app/500.html
@@ -14,6 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 {% include 'templates/head-meta.html' %}
 </head>
 <body class="fullbleed" unresolved>
+  {% include 'templates/noscript.html' %}
   <pw-shell>
     <style>
       .page-error {

--- a/app/about.html
+++ b/app/about.html
@@ -14,6 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 {% include 'templates/head-meta.html' %}
 </head>
 <body class="fullbleed" unresolved>
+  {% include 'templates/noscript.html' %}
   <pw-shell>
     {% include 'templates/site-nav.html' %}
 

--- a/app/community/index.html
+++ b/app/community/index.html
@@ -14,6 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 {% include 'templates/head-meta.html' %}
 </head>
 <body class="fullbleed" unresolved>
+  {% include 'templates/noscript.html' %}
   <pw-shell>
     {% include 'templates/site-nav.html' %}
     <style>

--- a/app/index.html
+++ b/app/index.html
@@ -14,6 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 {% include 'templates/head-meta.html' %}
 </head>
 <body class="fullbleed" unresolved>
+  {% include 'templates/noscript.html' %}
   <pw-shell>
     {% include 'templates/site-nav.html' %}
     <style>

--- a/app/sass/_main.scss
+++ b/app/sass/_main.scss
@@ -308,7 +308,7 @@ details {
 iron-doc-viewer, iron-doc-element, iron-doc-mixin, iron-doc-namespace {
   padding: 20px 40px;
   max-width: 800px;
-  
+
   @media (max-width: $mobile-media-breakpoint) {
     padding: 20px;
   }

--- a/app/search/index.html
+++ b/app/search/index.html
@@ -14,6 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 {% include 'templates/head-meta.html' %}
 </head>
 <body class="fullbleed" unresolved>
+  {% include 'templates/noscript.html' %}
   <pw-shell>
     {% include 'templates/site-nav.html' %}
 

--- a/templates/base-blog.html
+++ b/templates/base-blog.html
@@ -14,6 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 {% include 'templates/head-meta.html' %}
 </head>
 <body class="fullbleed" unresolved>
+  {% include 'templates/noscript.html' %}
   <pw-shell>
     {% include 'templates/site-nav.html' %}
 

--- a/templates/base-devguide.html
+++ b/templates/base-devguide.html
@@ -23,6 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </style>
 </head>
 <body class="fullbleed" unresolved>
+  {% include 'templates/noscript.html' %}
   <pw-shell>
     {% include 'templates/site-nav.html' %}
     {% if markdown %}

--- a/templates/noscript.html
+++ b/templates/noscript.html
@@ -1,0 +1,8 @@
+<!-- If JavaScript is disabled, we won't update any elements, so undo the FOUC styles -->
+<noscript>
+  <style type="text/css">
+    body, devguide-shell .sidenav-content, devguide-shell main {
+      opacity: 1 !important;
+    }
+  </style>
+</noscript>


### PR DESCRIPTION
When I started lazy-loading elements, I added a bunch of `opacity: 0` styles to prevent FOUC. If you're one for the 4 users that browses without JavaScript, you now see nothing.

I added a `<noscript>` style to get around that (but actually to not lose points on Lighthouse 😎)

@keanulee 

It doesn't look great, but I think that's fine. Here's what the top of `/2.0/docs/tools/polymer-cli` looks like:
<img width="1201" alt="screen shot 2017-03-21 at 3 41 02" src="https://cloud.githubusercontent.com/assets/1369170/24174303/2b19340c-0e4d-11e7-93ff-d822ef7e4ab0.png">
