### PR TITLE
Changed a MD table to HTML in upgrade.md

### DIFF
--- a/app/2.0/docs/upgrade.md
+++ b/app/2.0/docs/upgrade.md
@@ -79,12 +79,32 @@ break the existing, 1.x version of your element or app.
 
 Update the Polymer version in `bower.json` to the latest RC version.
 
-| Component | Version |
-|-----------|---------|
-| Polymer   | `2.0.0-rc.1` |
-| webcomponentsjs | `1.0.0-rc.4` |
-| web-component-tester | `6.0.0-prerelease.5` |
-| Polymer elements | `2.0-preview` |
+<table>
+<thead>
+<tr>
+<th>Component</th>
+<th>Version</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Polymer</td>
+<td><code>2.0.0-rc.1</code></td>
+</tr>
+<tr>
+<td>webcomponentsjs</td>
+<td><code>1.0.0-rc.4</code></td>
+</tr>
+<tr>
+<td>web-component-tester</td>
+<td><code>6.0.0-prerelease.5</code></td>
+</tr>
+<tr>
+<td>Polymer elements</td>
+<td><code>2.0-preview</code></td>
+</tr>
+</tbody>
+</table>
 
 Example dependencies {.caption}
 


### PR DESCRIPTION
The markdown table is not rendering to html so I've changed it o an html table.
This way agrees with the file [`about_20.md`](https://github.com/Polymer/docs/blob/master/app/2.0/docs/about_20.md).

![screenshot 9](https://cloud.githubusercontent.com/assets/3613094/24251818/39b7fae8-0fba-11e7-98ff-7efd4c118228.png)

It may be some deeper markdown error but I don't even know were to look (where is this markdown rendered into html?)

Also, no tests where made, except I got the following result when replacing the text in the browser myself:

![screenshot 10](https://cloud.githubusercontent.com/assets/3613094/24252110/4aad798a-0fbb-11e7-892d-858773034e7a.png)