### PR TITLE
add a version label to search results

### DIFF
--- a/app/elements/pw-shell.html
+++ b/app/elements/pw-shell.html
@@ -458,9 +458,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       } else if (response.items) {
         section = resultsElement.querySelector('.yes-results');
 
+        // Clean up the version bit for easier using.
+        for (var item = 0; item < response.items.length; item++) {
+          response.items[item].version = response.items[item].labels[0].displayName;
+        }
+
         // Populate the results in the dom-repeat.
         section.querySelector('template').items = response.items;
-
         var queryPrefix = '?q=' + this._searchParams.q + '&start=';
         var button = section.querySelector('.next-results');
         if (response.queries.nextPage) {

--- a/app/elements/pw-shell.html
+++ b/app/elements/pw-shell.html
@@ -445,6 +445,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _handleSearchResponse: function(event) {
+      var i;  // the linter which may not be named has issues.
       var response = event.detail.response;
 
       // Hide the existing section being displayed.
@@ -460,12 +461,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         // Clean up the version bit for easier using.
         for (var item = 0; item < response.items.length; item++) {
-          response.items[item].version = response.items[item].labels[0].displayName;
+          response.items[item].label = response.items[item].labels[0].displayName;
         }
 
         // Populate the results in the dom-repeat.
         section.querySelector('template').items = response.items;
-        var queryPrefix = '?q=' + this._searchParams.q + '&start=';
+
+        // Restricted search buttons. Ugh, so. we use the (undocumented) +more:version
+        // search parameter, which means we need to uhhh remove the +more
+        // keyword by hand if it already exists.
+        var matches = this._searchParams.q.match(/(.*) more:(1\.0|2\.0|Blog)/);
+        var searchParams;
+        var activeLabel;
+        if (matches && matches.length > 2) {
+          searchParams = matches[1];
+          activeLabel = matches[2]
+        }
+
+        var queryPrefix = '?q=' + (searchParams ? searchParams : this._searchParams.q);
+
+        var labels = resultsElement.querySelectorAll('a.search-filter');
+        for (i = 0; i < labels.length; i++) {
+          if (labels[i].dataset.label === 'all') {
+            labels[i].href = queryPrefix;
+            this.toggleClass('active', !activeLabel,  labels[i]);
+          } else {
+            labels[i].href = queryPrefix + '+more:' + labels[i].dataset.label;
+            this.toggleClass('active', labels[i].dataset.label === activeLabel, labels[i]);
+          }
+        }
+
+        // Previous and Next buttons.
+        queryPrefix += '&start=';
+
         var button = section.querySelector('.next-results');
         if (response.queries.nextPage) {
           this.toggleClass('button-hidden', false, button);
@@ -485,7 +513,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // There's a bunch of places where we displayed what you searched for.
       var queryElements = section.querySelectorAll('.search-query');
-      for (var i = 0; i < queryElements.length; i++) {
+      for (i = 0; i < queryElements.length; i++) {
         queryElements[i].textContent = this._searchParams.q;
       }
 

--- a/app/elements/pw-shell.html
+++ b/app/elements/pw-shell.html
@@ -456,6 +456,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       resultsElement.querySelector('section > div:not([hidden])').hidden = true;
 
       var section;  // The results section that we're going to show.
+      var searchParams = this._searchParams.q;
 
       if (!response || !response.items) {
         section = resultsElement.querySelector('.no-results');
@@ -473,15 +474,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         // Restricted search buttons. Ugh, so. we use the (undocumented) +more:version
         // search parameter, which means we need to uhhh remove the +more
         // keyword by hand if it already exists.
-        var matches = this._searchParams.q.match(/(.*) more:(1\.0|2\.0|Blog)/);
-        var searchParams;
+        var matches = searchParams.match(/(.*) more:(1\.0|2\.0|Blog)/);
         var activeLabel;
         if (matches && matches.length > 2) {
           searchParams = matches[1];
           activeLabel = matches[2];
         }
-
-        var queryPrefix = '?q=' + (searchParams ? searchParams : this._searchParams.q);
+        var queryPrefix = '?q=' + searchParams;
 
         var labels = resultsElement.querySelectorAll('a.search-filter');
         for (i = 0; i < labels.length; i++) {
@@ -517,7 +516,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // There's a bunch of places where we displayed what you searched for.
       var queryElements = section.querySelectorAll('.search-query');
       for (i = 0; i < queryElements.length; i++) {
-        queryElements[i].textContent = this._searchParams.q;
+        queryElements[i].textContent = searchParams;
       }
 
       // Flawless victory.

--- a/app/elements/pw-shell.html
+++ b/app/elements/pw-shell.html
@@ -355,7 +355,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _searchParamsChanged: function(newParams, oldParams) {
-      if (!!oldParams && oldParams.start !== newParams.start) {
+      // Either the whole query may have changed (because we added or changed
+      // the +more: search parameter, or the start page has changed in the
+      // same query)
+      if (!!oldParams && (newParams !== oldParams || oldParams.start !== newParams.start)) {
         this._doSearch();
       }
     },

--- a/app/elements/pw-shell.html
+++ b/app/elements/pw-shell.html
@@ -458,6 +458,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var section;  // The results section that we're going to show.
       var searchParams = this._searchParams.q;
 
+      // Ugh, so. we use the (undocumented) +more:version
+      // search parameter, which means we need to uhhh remove the +more
+      // keyword by hand if it already exists.
+      var matches = searchParams.match(/(.*) more:(1\.0|2\.0|Blog)/);
+      var activeLabel;
+      if (matches && matches.length > 2) {
+        searchParams = matches[1];
+        activeLabel = matches[2];
+      }
+
+      // Restricted search buttons.
+      var queryPrefix = '?q=' + searchParams;
+      var labels = resultsElement.querySelectorAll('a.search-filter');
+      for (i = 0; i < labels.length; i++) {
+        if (labels[i].dataset.label === 'all') {
+          labels[i].href = queryPrefix;
+          this.toggleClass('active', !activeLabel,  labels[i]);
+        } else {
+          labels[i].href = queryPrefix + '+more:' + labels[i].dataset.label;
+          this.toggleClass('active', labels[i].dataset.label === activeLabel, labels[i]);
+        }
+      }
+
       if (!response || !response.items) {
         section = resultsElement.querySelector('.no-results');
       } else if (response.items) {
@@ -470,28 +493,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         // Populate the results in the dom-repeat.
         section.querySelector('template').items = response.items;
-
-        // Restricted search buttons. Ugh, so. we use the (undocumented) +more:version
-        // search parameter, which means we need to uhhh remove the +more
-        // keyword by hand if it already exists.
-        var matches = searchParams.match(/(.*) more:(1\.0|2\.0|Blog)/);
-        var activeLabel;
-        if (matches && matches.length > 2) {
-          searchParams = matches[1];
-          activeLabel = matches[2];
-        }
-        var queryPrefix = '?q=' + searchParams;
-
-        var labels = resultsElement.querySelectorAll('a.search-filter');
-        for (i = 0; i < labels.length; i++) {
-          if (labels[i].dataset.label === 'all') {
-            labels[i].href = queryPrefix;
-            this.toggleClass('active', !activeLabel,  labels[i]);
-          } else {
-            labels[i].href = queryPrefix + '+more:' + labels[i].dataset.label;
-            this.toggleClass('active', labels[i].dataset.label === activeLabel, labels[i]);
-          }
-        }
 
         // Previous and Next buttons.
         queryPrefix += '&start=';

--- a/app/elements/pw-shell.html
+++ b/app/elements/pw-shell.html
@@ -478,7 +478,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var activeLabel;
         if (matches && matches.length > 2) {
           searchParams = matches[1];
-          activeLabel = matches[2]
+          activeLabel = matches[2];
         }
 
         var queryPrefix = '?q=' + (searchParams ? searchParams : this._searchParams.q);

--- a/app/search/index.html
+++ b/app/search/index.html
@@ -38,6 +38,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         margin-bottom: 20px;
       }
 
+      .search-result .version {
+        color: white;
+        padding: 5px 10px;
+        text-align: center;
+        font-weight: bold;
+        border-radius: 3px;
+      }
+
+      .search-result .version[data-version="1.0"] {
+        background-color: #37474f;
+      }
+
+      .search-result .version[data-version="2.0"] {
+        background-color: #1565C0;
+      }
+
       .results-button-container {
         display: flex;
         flex-direction: row;
@@ -61,6 +77,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <br>
           <template is="dom-repeat">
             <div class="search-result">
+              <span class="version" data-version$={{item.version}}>{{item.version}}</span>
               <a href="{{item.link}}">{{item.title}}</a>
               <p class="snippet">{{item.snippet}}</p>
             </div>

--- a/app/search/index.html
+++ b/app/search/index.html
@@ -51,7 +51,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       .search-result .version[data-version="2.0"] {
-        background-color: #1565C0;
+        background-color: #1565c0;
+      }
+
+      .search-result .version[data-version="Blog"] {
+        background-color: #e8345a;
       }
 
       .results-button-container {
@@ -77,7 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <br>
           <template is="dom-repeat">
             <div class="search-result">
-              <span class="version" data-version$={{item.version}}>{{item.version}}</span>
+              <span class="version" data-version$="{{item.version}}">{{item.version}}</span>
               <a href="{{item.link}}">{{item.title}}</a>
               <p class="snippet">{{item.snippet}}</p>
             </div>

--- a/app/search/index.html
+++ b/app/search/index.html
@@ -90,6 +90,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <h2>Search</h2>
           <p>Use the search bar above to search the site.</p>
         </div>
+
         <div class="yes-results" hidden>
           <h2>Search results for <span class="search-query"></span></h2>
           <div>
@@ -100,6 +101,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <a class="search-filter" data-label="all">All</a>
           </div>
           <br><br>
+
           <template is="dom-repeat">
             <div class="search-result">
               <span class="search-label" data-label$="{{item.label}}">{{item.label}}</span>
@@ -116,6 +118,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         <div class="no-results" hidden>
           <h2>Search results for <span class="search-query"></span></h2>
+          <div>
+            Filter by:
+            <a class="search-filter" data-label="1.0">1.0</a>|
+            <a class="search-filter" data-label="2.0">2.0</a>|
+            <a class="search-filter" data-label="Blog">Blog</a>|
+            <a class="search-filter" data-label="all">All</a>
+          </div>
+          <br>
           <p>Your search — <span class="search-query small"></span> — did not match any documents.</p>
           <p>Suggestions:</p>
           <ul>

--- a/app/search/index.html
+++ b/app/search/index.html
@@ -38,7 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         margin-bottom: 20px;
       }
 
-      .search-result .version {
+      .search-label {
         color: white;
         padding: 5px 10px;
         text-align: center;
@@ -46,16 +46,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         border-radius: 3px;
       }
 
-      .search-result .version[data-version="1.0"] {
+      a.search-filter {
+        padding: 0 10px;
+        display: inline-block;
+        cursor: pointer;
+      }
+
+      a.search-filter.active {
+        color: #f50057;
+      }
+
+      .search-label[data-label="1.0"] {
         background-color: #37474f;
       }
 
-      .search-result .version[data-version="2.0"] {
+      .search-label[data-label="2.0"] {
         background-color: #1565c0;
       }
 
-      .search-result .version[data-version="Blog"] {
+      .search-label[data-label="Blog"] {
         background-color: #e8345a;
+      }
+
+      .search-label[data-label="all"] {
+        color: black;
       }
 
       .results-button-container {
@@ -78,10 +92,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </div>
         <div class="yes-results" hidden>
           <h2>Search results for <span class="search-query"></span></h2>
-          <br>
+          <div>
+            Filter by:
+            <a class="search-filter" data-label="1.0">1.0</a>|
+            <a class="search-filter" data-label="2.0">2.0</a>|
+            <a class="search-filter" data-label="Blog">Blog</a>|
+            <a class="search-filter" data-label="all">All</a>
+          </div>
+          <br><br>
           <template is="dom-repeat">
             <div class="search-result">
-              <span class="version" data-version$="{{item.version}}">{{item.version}}</span>
+              <span class="search-label" data-label$="{{item.label}}">{{item.label}}</span>
               <a href="{{item.link}}">{{item.title}}</a>
               <p class="snippet">{{item.snippet}}</p>
             </div>


### PR DESCRIPTION
Looks like this. I don't think the search results are sorted by 2.0 first, which kinda sucks.

<img width="968" alt="screen shot 2017-04-19 at 5 59 52" src="https://cloud.githubusercontent.com/assets/1369170/25208544/46f1f99a-252a-11e7-9acb-8569bf65d704.png">

@keanulee @arthurevans 
