### PR TITLE
Cleanup styles a bit

### DIFF
--- a/app/elements/devguide-shell.html
+++ b/app/elements/devguide-shell.html
@@ -15,17 +15,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       :host {
         display: block;
         position: relative;
-        background: #fafafa;  /* pale-grey */
+        background: white;
       }
 
       nav {
         position: absolute;
         top: 0;
         bottom: 0;
-        background: white;
+        background: #f4f5f6;
         width: 265px;
         z-index: 2;
-        box-shadow: 1px 0 6px -2px rgba(0, 0, 0, 0.4);
+        /*box-shadow: 1px 0 6px -2px rgba(0, 0, 0, 0.4);*/
         padding-top: 10px;
         overflow-x: hidden;
         overflow-y: auto;
@@ -42,7 +42,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       header.v2 {
-        background: #1565c0;  /* blue-800 */
+        background: #1E88E5;  /* blue-600 */
       }
 
       header.v1 {
@@ -93,7 +93,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       iron-selector ::content .sidenav-header {
-        font-family: 'Roboto Slab', 'Roboto', 'Noto', sans-serif;
         padding-top: 15px;
         font-weight: bold;
         /* The active links will have a pink border. */
@@ -102,12 +101,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       iron-selector ::content .sidenav-header:first-of-type {
         margin-top: 15px;
-        border-top: 1px solid #eceff1;
+        border-top: 1px solid #eaedef;
       }
 
       iron-selector ::content .sidenav-endheader {
         margin-top: 15px;
-        border-bottom: 1px solid #eceff1;
+        border-bottom: 1px solid #eaedef;
       }
 
       iron-selector ::content a.iron-selected {

--- a/app/elements/devguide-shell.html
+++ b/app/elements/devguide-shell.html
@@ -59,7 +59,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       header p {
         margin: 0;
+        font-weight: bold;
       }
+      
       /* can't apply a custom property to content */
       iron-selector {
         @apply --paper-font-common-base;
@@ -121,7 +123,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         text-transform: uppercase;
         font-size: 13px;
         text-decoration: none;
-        font-weight: bold;
       }
 
       .version-alert {

--- a/app/elements/devguide-shell.html
+++ b/app/elements/devguide-shell.html
@@ -101,12 +101,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       iron-selector ::content .sidenav-header:first-of-type {
         margin-top: 15px;
-        border-top: 1px solid #eaedef;
+        border-top: 1px solid #E0E0E0;
       }
 
       iron-selector ::content .sidenav-endheader {
         margin-top: 15px;
-        border-bottom: 1px solid #eaedef;
+        border-bottom: 1px solid #E0E0E0;
       }
 
       iron-selector ::content a.iron-selected {
@@ -121,6 +121,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         text-transform: uppercase;
         font-size: 13px;
         text-decoration: none;
+        font-weight: bold;
       }
 
       .version-alert {

--- a/app/sass/_main.scss
+++ b/app/sass/_main.scss
@@ -66,7 +66,7 @@ devguide-shell {
 a {
   color: $blue-600;
   text-decoration: none;
-  font-weight: 400;
+  font-weight: 500;
 
   &:hover {
     text-decoration: underline;
@@ -203,7 +203,7 @@ section {
 h2 {
   font-family: 'Roboto Slab', 'Roboto', 'Noto', sans-serif;
   font-size: 24px;
-  font-weight: 700;
+  font-weight: 300;
   line-height: 38px;
   margin: 10px 0;
 

--- a/app/sass/_material.scss
+++ b/app/sass/_material.scss
@@ -54,7 +54,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   @include md-font-base();
   font-size: 45px;
   font-weight: 400;
-  letter-spacing: -.018em;
   line-height: 48px;
 }
 

--- a/templates/base-blog.html
+++ b/templates/base-blog.html
@@ -34,7 +34,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       .article {
         margin-bottom: 40px;
-        border-left: 1px solid #e4e5e6;
+        border-left: 3px solid #1E88E6;
         padding-left: 30px;
       }
 

--- a/templates/base-blog.html
+++ b/templates/base-blog.html
@@ -34,6 +34,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       .article {
         margin-bottom: 40px;
+        border-left: 1px solid #e4e5e6;
+        padding-left: 30px;
+      }
+
+      h2 {
+        font-family: Helvetica, Arial, sans-serif;
+        margin: 0;
+      }
+
+      .article h2 a {
+        color: black;
       }
 
       .author img {
@@ -65,6 +76,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         max-width: 1000px;
       }
 
+      .byline {
+        color: #757575;
+      }
+
       .author > p {
         display: inline-block;
         margin: 0;
@@ -88,10 +103,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       /* Match the main media-queries to the header, but don't worry about centering
        * the content, since we do that separately.
        */
-      .main-section {
-        background: #fafafa;
-      }
-
       @media (min-width: 1001px) {
         .main-section {
           padding-right: 40px;  /* So that the TOC doesn't jump */
@@ -169,13 +180,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div class="article">
         <h2><a href="{{{item.path}}}.html">{{{item.title}}}</a></h2>
         <div class="byline author">
-          <p>
-            <a href="https://plus.google.com/{{{item.author.gplus}}}" target="blank_">
-              <img src="{{{item.author.profile_pic}}}" alt="{{{item.author.full_name}}} profile pic" title="{{{item.author.full_name}}}">
-            </a>
-            <a href="{{{item.author.web}}}" target="blank_">{{{item.author.full_name}}}</a>
-          </p>
-          <p>, <time pubdate="" datetime="{{{item.published}}}">{{{item.published}}}</time></p>
+          <time pubdate="" datetime="{{{item.published}}}">{{{item.published}}}</time>
         </div>
         <p>{{{item.description}}}</p>
       </div>

--- a/templates/head-meta.html
+++ b/templates/head-meta.html
@@ -10,7 +10,7 @@
 
 <link rel="publisher" href="https://plus.google.com/107187849809354688692">
 <link rel="shortcut icon" href="/images/logos/p-logo-32.png">
-<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400,700|Roboto+Slab:400,700">
+<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400,700|Roboto+Slab:300,500">
 
 <link rel="stylesheet" href="/css/site.css">
 

--- a/templates/page-md-styles.html
+++ b/templates/page-md-styles.html
@@ -1,7 +1,7 @@
 <style>
   main {
     position: relative;
-    background: #fafafa;
+    background: white;
     padding: 10px 40px;
     font-size: 16px;
     font-family: 'Roboto', 'Noto', sans-serif;
@@ -100,12 +100,11 @@
   @media (min-width: 1001px) {
     details {
       padding-left: 20px;
-      border-left: 2px solid #eceff1;
+      border-left: 1px solid black;
     }
   }
 
   details summary {
-    font-family: 'Roboto Slab', 'Roboto', 'Noto', sans-serif;
     font-weight: bold;
     font-size: 15px;
     line-height: 24px;
@@ -139,12 +138,15 @@
   }
 
   h2 {
+    font-family: Helvetica, Arial, sans-serif;
+    font-weight: bold;
     border-bottom: 1px solid #f50057;
     margin: 20px 0;
   }
 
   h3 {
-    font-family: 'Roboto Slab', 'Roboto', 'Noto', sans-serif;
+    font-family: Helvetica, Arial, sans-serif;
+    font-weight: bold;
     font-size: 24px;
   }
 
@@ -231,7 +233,7 @@
   }
 
   code.hljs {
-    background: white;
+    background: #f5f5f5;
     font-weight: 400;
   }
 


### PR DESCRIPTION
Ok, controversial PR here. I changed some styles; they're all up for discussion. The PR is actually a bit old, I just forgot about it
Live link: https://cleanup-styles-dot-polymer-project.appspot.com/

@arthurevans @keanulee 

Docs page:
- made the blue lighter
- flattened the left nav, and made it grey (to make the content white)
- used the sans-serif in the nav, and a thinner slab in the title:
- also made the section titles not slabby
<img width="1331" alt="screen shot 2017-04-19 at 6 11 06" src="https://cloud.githubusercontent.com/assets/1369170/25208776/a1764654-252b-11e7-9560-9e6b01f22782.png">
<img width="657" alt="screen shot 2017-04-19 at 6 12 28" src="https://cloud.githubusercontent.com/assets/1369170/25208795/cc00df38-252b-11e7-94db-68a1245d71e0.png">

Main page:
- thinner slabs in the titles:
<img width="753" alt="screen shot 2017-04-19 at 6 13 06" src="https://cloud.githubusercontent.com/assets/1369170/25208809/e216e2cc-252b-11e7-9af4-92d27bb75b18.png">

Blog:
- nuked the slabs
- changed the blog items a lot:
<img width="1241" alt="screen shot 2017-04-19 at 6 13 33" src="https://cloud.githubusercontent.com/assets/1369170/25208829/024d34ce-252c-11e7-8c47-b6e8651ae7e9.png">



