### PR TITLE
Call scrollToAnchor on the iron-doc-* we're rendering.

### DIFF
--- a/app/elements/pw-shell.html
+++ b/app/elements/pw-shell.html
@@ -582,7 +582,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (el) {
           el.scrollIntoView();
         } else {
-          var viewer = Polymer.dom(this).querySelector('iron-doc-viewer');
+          var viewer = Polymer.dom(this).querySelector(
+            'iron-doc-element, iron-doc-mixin, iron-doc-namespace');
           if (viewer)
             viewer.scrollToAnchor(hash);
         }


### PR DESCRIPTION
Depends on https://github.com/PolymerElements/iron-doc-viewer/pull/116.
cc @arthurevans