### PR TITLE
cleanup existing/out of date tooling documentation

### DIFF
--- a/app/2.0/docs/tools/optimize-for-production.md
+++ b/app/2.0/docs/tools/optimize-for-production.md
@@ -4,13 +4,79 @@ title: Optimize for production
 
 <!-- toc -->
 
-[Polymer CLI](polymer-cli) is the recommended starting point for building
-Polymer applications. If for some reason it does not meet your needs, you
-can use the underlying libraries that power its build toolchain. See
-[Advanced tools](advanced#build) for a list of these tools.
+The Polymer CLI includes a `build` command to generate a production-ready build of your application. This process can include minifying code, compiling JavaScript, automatic service worker generation, and more.
 
-See the [polymer.json specification](polymer-json) for a reference to the available Polymer CLI
-build options.
+Polymer CLI's build process works best with applications that follow the [app shell architecture](https://developers.google.com/web/updates/2015/11/app-shell). To configure your app as an App Shell application, create a `polymer.json` file at the top-level of your project and set the `entrypoint`, `shell`, and `fragments` options for your application.
 
-This document will be updated with more information on using the advanced build tools in the
-Polymer 2.x toolchain.
+You can configure your build via the following command-line flags. However, we reccomend saving these values in your polymer.json. That way there's no concern about remembering the same flags for every build. [See the `polymer.json` specification for more information](polymer-json).
+
+* [`--add-service-worker`](#service-workers)
+* [`--bundle`](#bundles)
+* [`--css-minify`](#css-minify)
+* [`--entry`](#entrypoint)
+* [`--html-minify`](#html-minify)
+* [`--insert-prefetch-links`](#prefetch)
+* [`--js-compile`](#js-compile)
+* [`--js-minify`](#js-minify)
+* [`--shell`](#shell)
+* [`--fragment`](#fragment)
+
+#### `--add-service-worker` {#service-workers}
+
+Generate a service worker for your application to cache all files and assets on the client.
+
+Polymer CLI will generate a service worker for your build using the
+[sw-precache](https://github.com/GoogleChrome/sw-precache) library. To customize your service worker, create a `sw-precache-config.js` file in your project directory that exports your configuration. See the [sw-precache README](https://github.com/GoogleChrome/sw-precache) for a list of all supported options.
+
+Note that the sw-precache library uses a cache-first strategy for maximum speed and makes some other assumptions about how your service worker should behave. Read the ["Considerations"](https://github.com/GoogleChrome/sw-precache#considerations) section of the sw-precache README to make sure that this is suitable for your application.
+
+#### `--bundle` {#bundles}
+
+By default, fragments are unbundled. This is optimal for HTTP/2-compatible servers and clients.
+
+If the `--bundle` flag is supplied, all fragments are bundled together to reduce the number of file requests. This is optimal for sending to clients or serving from servers that are not HTTP/2 compatible.
+
+#### `--css-minify` {#css-minify}
+
+Minify inlined and external CSS.
+
+#### `--entry` {#entrypoint}
+
+A filename. This is the main entrypoint into your application for all routes. Often times this is your `index.html` file. This file should import the app shell file specified in the [`shell`](#shell) option. It should be minimal since it's loaded and cached for each route.
+
+#### `--html-minify` {#html-minify}
+
+Minify HTMl by removing comments and whitespace.
+
+#### `--insert-prefetch-links` {#prefetch}
+Insert prefetch link elements into your fragments so that all dependencies are prefetched immediately. Add dependency prefetching by inserting `<link rel="prefetch">` tags into entrypoint and `<link rel="import">` tags into fragments and shell for all dependencies.
+
+#### `--js-compile` {#js-compile}
+
+Use babel to compile all ES6 JS down to ES5 for older browsers.
+
+#### `--js-minify` {#js-minify}
+
+Minify inlined and external JavaScript.
+
+#### `--shell` {#shell}
+
+The app shell file containing common code for the app.
+
+#### `--fragment` {#fragment}
+
+This flag supports dynamic dependencies. It is an array of any HTML filenames that are not statically linked from the app shell (that is, imports loaded on demand by `importHref`).
+
+If a fragment has static dependencies, provided the fragment is defined in this property, the Polymer build analyzer will find them. You only need to list the file imported by importHref.
+
+In a Polymer app, the files listed in the fragments flag usually contain one or more element definitions that may or may not be required during the user’s interaction with the app, and can thus be lazily loaded.
+
+#### Examples {#examples}
+
+Create a bundled, minified application build:
+
+`polymer build --bundle --js-minify --css-minify --html-minify`
+
+Create an unbundled, minified application build:
+
+`polymer build --js-minify --css-minify --html-minify`

--- a/app/2.0/docs/tools/overview.md
+++ b/app/2.0/docs/tools/overview.md
@@ -2,16 +2,11 @@
 title: Tools overview
 ---
 
-The Polymer Project offers a range of tools for developing, building, and 
-optimizing Polymer elements and apps. 
+The Polymer Project offers a range of tools to help developers write web components.
 
-You can use Polymer CLI for the vast majority of your Polymer development tasks. 
-Read [Polymer CLI](polymer-cli) to get started. 
+The [Polymer CLI](polymer-cli) is our reccomended "swiss army knife" for Polymer tooling. It supports a collection of commands for common scenarios like serving, testing, and initializing new projects from templates.
 
-For use cases Polymer CLI doesn't handle, you can customize your toolchain. 
-Check out [Advanced tools](advanced) for a description of the underlying tools 
-that Polymer CLI is composed of, and then use a build tool like Grunt or 
-Gulp to automate your workflow. 
+For advanced tooling configurations that the CLI may not handle, check out our [Advanced tools](advanced) section. The Polymer CLI is composed of lower-level tooling that you are welcome to use directly. For example, the [`polymer-build`](https://github.com/Polymer/polymer-build) library helps you create your own build process out of pluggable streams.
 
-In addition, the [Services](services) doc lists some web services that you may find useful when developing with Polymer (such as the Polygit development CDN for rapidly prototyping elements). 
+In addition, the [Web services](services) page lists helpful services to speed up the development process.
 

--- a/app/2.0/docs/tools/polymer-cli.md
+++ b/app/2.0/docs/tools/polymer-cli.md
@@ -14,6 +14,8 @@ $ yarn add global polymer-cli
 $ npm install -g polymer-cli
 ```
 
+Also make sure that your version of Node.js is supported by the Polymer CLI. Run `node --version` to check the version of Node.js that you have installed and see our official [node version support policy](node-support) for more details.
+
 ## Overview {#overview}
 
 The Polymer CLI is our official command-line tool for Polymer projects and Web Components. Its features include:

--- a/app/2.0/docs/tools/polymer-cli.md
+++ b/app/2.0/docs/tools/polymer-cli.md
@@ -4,476 +4,84 @@ title: Polymer CLI
 
 <!-- toc -->
 
-Polymer CLI is still pre-release. Some options may be subject to change.
-{.alert .alert-warning}
-
 ## Install {#install}
 
-1.  Install [Git](https://git-scm.com/downloads).
+The Polymer CLI can be installed with either [Yarn](https://yarnpkg.com/en/) or [npm](https://www.npmjs.com/). Yarn is the reccomended installation method due to it's faster and more dependable installations.
 
-1.  Install an [active LTS version of Node.js](https://github.com/nodejs/LTS) (4.x or 6.x). The
-current version (7.x) should work, but is not
-    officially supported.
-
-1.  Update npm.
-
-        npm install npm@latest -g
-
-1.  Install the latest version of Bower.
-
-        npm install -g bower
-
-1.  Install Polymer CLI.
-
-        npm install -g polymer-cli@next
-
-You're all set. Run `polymer help` to view a list of commands.
+```bash
+$ yarn add global polymer-cli
+# or...
+$ npm install -g polymer-cli
+```
 
 ## Overview {#overview}
 
-Polymer CLI is a command-line interface for Polymer projects. It includes a build pipeline, a
-boilerplate generator for creating elements and apps, a linter, a development server, and a test
-runner.
+The Polymer CLI is our official command-line tool for Polymer projects and Web Components. Its features include:
 
-Polymer CLI works with two types of projects:
+  - **init** - Create a new Polymer project from pre-configured starter templates
+  - **install** - Install dependencies and [dependency variants](https://www.polymer-project.org/2.0/docs/glossary#dependency-variants) via Bower
+  - **serve**	- Serve elements and applications during development
+  - **lint** - Lint a project to find and diagnose errors quickly
+  - **test** - Test your project with [`web-component-tester`](https://github.com/Polymer/web-component-tester/)
+  - **build**	- Build an application optimized for production
+  - **analyze** - Generate an analyzed JSON representation of your element or application
 
-* Elements projects. In an element project, you expose a single element or
-  group of related elements which you intend to use
-  in other element or app projects, or
-  distribute on a registry like Bower or NPM. Elements are reusable and
-  organized to be used alongside other elements, so components are referenced
-  outside the project.
-* Application projects. In an app project, you build an application, composed
-  of Polymer elements, which you intend to deploy as a website. Applications are
-  self-contained, organized with components inside the application.
+Run `polymer help` for an up-to-date list of all supported commands, and run `polymer help COMMAND_NAME` for information about specific command features and options.
 
-Complete the [Install](#install) section to learn how to install
-Polymer CLI and then proceed to the [Build an element](#element) or
-[Build an app](#app) section to get started on your first project.
 
-## Create an element project {#element}
+## Supported Dependencies {#dependencies}
 
-This section shows you how to start an element project.
+Polymer CLI assumes all projects install dependencies in a flat directory. Polymer officially supports (and strongly reccomends) using [Bower](http://bower.io) for dependency management. [Yarn](https://yarnpkg.com/en/) also supports a `--flat` install, but this is considered experimental for Polymer projects at this time.
 
-1.  Create a directory for your element project. It's best practice for the name
-    of your project directory to match the name of your element.
+`polymer install` is a helpful shortcut to install your project's Bower dependencies (aliases to `bower install`).
 
-    <pre><code>mkdir <var>my-el</var> && cd <var>my-el</var></code></pre>
 
-    Where <code><var>my-el</var></code> is the name of the element you're
-    creating.
+#### Supported Projects {#element-imports}
 
-1.  Initialize your element. Polymer CLI asks you a few
-    questions as it sets up your element project.
+Polymer CLI works with three types of projects:
 
-        polymer init
+* **Elements:** An element project exposes a single element or
+  group of related elements to be consumed by other elements or applications. Elements are reusable and are meant to live alongside other dependencies in your project, so other components are referenced
+  outside the project. Polymer tooling will help you work with these elements.
+* **Simple Applications:** An application project is a web application that can be deployed as a website. Applications are self-contained, with application elements organized inside the application.
+* **[App-Shell Applications]((https://developers.google.com/web/updates/2015/11/app-shell)):** A type of web application that adheres to a specific structure. App-Shell applications are more performant in production and can take advantage of additional Polymer CLI build features (automatic code bundling, HTTP/2 push manifest generation, and more). To set up, configure the `entrypoint`, `shell`, and `fragments` properties in your [`polymer.json`](polymer-json).
 
-1.  Select `element`.
 
-1.  Enter a name for your element.
+#### Example: Building a Polymer Element
 
-    The [custom elements
-    specification](https://www.w3.org/TR/2016/WD-custom-elements-20160226/#concepts) requires the
-    element name to contain a dash.
-    {.alert .alert-info}
+`polymer init` offers several element templates to help you get started building a new element.
 
-1.  Enter a description of the element.
-
-At this point, Polymer CLI generates files and directories for your element,
-and installs your project's dependencies.
-
-### Element project layout
-
-After the initialization process Polymer CLI generates the following files and directories.
-
-*   `bower.json`. Configuration file for Bower.
-*   `bower_components/`. Project dependencies. See
-    [Manage dependencies](#dependencies).
-*   `demo/index.html`. Demo of <code><var>my-el</var></code>`.html`.
-*   `index.html`. Automatically-generated API reference.
-*   <code><var>my-el</var></code>`.html`. Element source code.
-*   `test/`<code><var>my-el</var></code>`_test.html`. Unit tests for
-    the element.
-
-#### HTML imports and dependency management {#element-imports}
-
-Summary:
-
-When importing Polymer elements via HTML imports, always use the relative URL
-<code>../<var>package-name</var>/<var>element-name</var>.html</code> (e.g.
-`../polymer/polymer.html` or `../paper-elements/paper-button.html`).
-
-Details:
-
-Suppose that you ran Polymer CLI to generate an element project. Your element is named `my-el`. You
-look inside `my-el.html` and see that Polymer has been
-imported like so:
-
-    <link rel="import" href="../polymer/polymer.html">
-
-This path doesn't make sense. Relative to `my-el.html`,
-Polymer is actually located at `bower_components/polymer/polymer.html`. Whereas
-the HTML import above is referencing a location *outside* of your element
-project. What's going on?
-
-Bower installs dependencies in a flat dependency tree, like so:
-
-    bower_components/
-      polymer/
-        polymer.html
-      my-el/
-        my-el.html
-      other-el/
-        other-el.html
-
-This works well on the application-level. All elements are siblings, so they can
-all reliably import each other using relative paths like
-`../polymer/polymer.html`. This is why Polymer CLI uses relative paths
-when initializing your element project.
-
-However, one problem with this approach, as stated earlier, is that this
-structure does not actually match the layout in your element project. Your
-element project is actually laid out like so:
-
-    bower_components/
-      polymer/
-        polymer.html
-    my-el.html
-
-Polymer CLI handles this by remapping paths. When you run `polymer serve`,
-all elements in `bower_components` are remapped to appear to be in sibling
-directories relative to `my-el`. The current element is served from the
-made-up path of <code>/components/<var>bower name</var></code>, where
-<code><var>bower name</var></code> is the `name` field from your element
-project's `bower.json` file.
-
-## Create an app project {#app}
-
-Polymer CLI supports initializing a project folder with one of
-several application templates.  The CLI comes with a `basic` template,
-which is the most basic starting point for a Polymer-based application,
-as well as others that introduce more complex layout and application patterns.
-
-This chapter teaches you more about `basic` app projects.  See
-[Polymer App Toolbox templates](../../toolbox/templates) for more details on
-other templates.
-
-### App project architecture {#app-architecture}
-
-Polymer CLI is designed for apps that follow the [app shell
-architecture](https://developers.google.com/web/updates/2015/11/app-shell).
-
-There are fundamental concepts of the app shell architecture that you should understand before
-creating your app project with Polymer CLI: the entrypoint,
-the shell, and fragments. See [App structure](/1.0/toolbox/server#app-structure)
-from the App Toolbox docs for an in-depth overview of these concepts.
-
-### Set up basic app project {#basic-app}
-
-Follow the steps below to get your `basic` app project set up.
-
-1.  Create a directory for your app project.
-
-    <pre><code>mkdir <var>app</var>
-    cd <var>app</var></code></pre>
-
-    Where <code><var>app</var></code> is the name of your project directory.
-
-1.  Initialize your app. Polymer CLI asks you a few questions
-    as it sets up your app.
-
-        polymer init
-
-1.  Select `application`.
-
-1.  Enter a name for your app. Defaults to the name of the current directory.
-
-1.  Enter a name for the main element in your project. The main element is the
-    top-most, application-level element of your app. Defaults to the name of
-    the current directory, followed by `-app`.
-
-    The code samples throughout this doc use the example app element name
-    <code><var>my-app</var></code>. When creating your app you'll want to
-    replace any instance of <code><var>my-app</var></code> with the name of
-    your main element.
-    {.alert .alert-info}
-
-1.  Enter a description for your app.
-
-At this point, Polymer CLI generates files and directories for your app,
-and installs your project's dependencies.
-
-### App project layout
-
-After the initialization process Polymer CLI generates the following files and directories.
-
-*   `bower.json`. Configuration file for Bower.
-*   `bower_components/`. Project dependencies. See
-    [Manage dependencies](#dependencies).
-*   `index.html`. Entrypoint page of the app.
-*   `src/`<code><var>my-app</var></code>/<code><var>my-app</var></code>`.html`.
-    Source code for main element.
-*    `test/`<code><var>my-app</var></code>/<code><var>my-app</var></code>`_test.html`. Tests for
-main element.
-
-#### Add elements
-
-You may want to compose your main element out of smaller, application-specific
-elements. These app-specific elements should be defined in the `src` directory, at the same level
-as <code><var>my-app</var></code>.
-
-    app/
-      src/
-        my-app/
-        my-el/
-
-Currently there is no Polymer CLI command to generate application-specific elements. You should do
-it by hand and should not create an [element project](#element) within your app project.
-
-## Commands {#commands}
-
-This section explains various useful Polymer CLI commands that you'll want to incorporate into your
-development workflow while you build your element or app project.
-
-The commands are intended for both element and app projects unless otherwise
-noted.
-
-* [`polymer test`](#tests)
-* [`polymer serve`](#serve)
-* [`polymer lint`](#lint)
-* [`polymer build` (for app projects only)](#build)
-
-### `polymer test` {#tests}
-
-Runs tests.
-
-If you want to run tests on your element or app project, `cd` to the base directory of your project
-and run:
-
-    polymer test
-
-Polymer CLI automatically runs all of the tests that it finds in the `test` directory. You'll see
-the results of the tests in your CLI.
-
-If you create your own tests, they should also go in the `test` directory.
-
-The underlying library that powers `polymer test` is called `web-component-tester` (`wct`). Learn
-more about creating unit tests with `wct`
-in [Test your elements](/1.0/tools/tests).
-
-### `polymer serve` {#serve}
-
-Runs a local web server.
-
-If you want to view a live demo of your element or app, run the local web server:
-
-    polymer serve
-
-To view the demo, point your browser to one of the following URLs.
-
-Element project demo:
-
-<pre><code>http://localhost:8080/components/<var>my-el</var>/demo/</code></pre>
-
-Element project API reference:
-
-<pre><code>localhost:8080/components/<var>my-el</var>/</code></pre>
-
-App project demo:
-
-    http://localhost:8080
-
-#### Server options {#server-options}
-
-This section shows examples of using various `polymer serve` options.
-
-Serve from port 3000:
-
-    polymer serve --port 3000
-
-If you have configured a custom hostname on your machine, Polymer CLI can serve it with the
-`--hostname` argument (for example, app project demo is available at `http://test:8080`):
-
-    polymer serve --hostname test
-
-Open up a page other than the default `index.html` in a specific browser
-(Apple Safari, in this case):
-
-    polymer serve --open app.html --browser Safari
-
-### `polymer lint` {#lint}
-
-Analyze your project for syntax errors, missing imports, bad databinding expressions and more. `polymer lint` helps with identifying issues across your HTML, JS, and CSS based on an in-depth analysis of web components in source code. It does not reinvent the wheel though, it focuses on issues specific to web components and Polymer, so it is a good adjunct to other tools like [`eslint`](http://eslint.org/) and [`htmlhint`](http://htmlhint.com/).
-
-Use it like so:
-
-    polymer lint --rules=polymer-2
-
-This will lint all of the code in your project with the `polymer-2` ruleset, which is appropriate for projects using Polymer 2.0. If your code is hybrid and should with with either Polymer 1.0 or 2.0 then `polymer-2-hybrid` is a better choice, as it will warn you about use of features that do not exist in Polymer 2.0.
-
-You can pass flags to the linter like `--rules` but even better is to put the configuration in `polymer.json` so that all you need to do is run `polymer lint`. Putting your configuration in `polymer.json` also means that other tools, like IDE plugins can use the same lint configuration.
-
-Here's what that looks like:
-
-```json
-{
-  "lint": {
-      "rules": ["polymer-2"],
-      "ignoreWarnings": []
-  }
-}
-```
-
-- `rules`: An array of lint rules and rule collections to run on your project. For most projects, one of  `polymer-2`, `polymer-2-hybrid`, or `polymer-1` is all that's needed here.
-- `ignoreWarnings`: An array of warning codes to ignore.
-
-#### Warning Codes:
-
-The output of `polymer lint` looks like this:
+When importing dependencies inside your element, you should always use a relative URL *as if dependency is a sibling of your project.*
 
 ```
-            <iron-collapse>
-            ~~~~~~~~~~~~~~~
-
-index.html(83,12) warning [undefined-elements] - The element iron-collapse is not defined
+<!-- from a top-level 'some-element.html' -->
+<link rel="import" href="../polymer/polymer.html">
 ```
 
-This means that on line 83 of `index.html` there's an `<iron-collapse>` tag, but the linter can't find the definition of the `iron-collapse` custom element. This probably means that there's a missing HTML import in `index.html`. To ignore this warning, add `undefined-elements` to the `ignoreWarnings` array in `polymer.json`.
+This may feel weird, but remember that dependencies are siblings of each other. So write your paths as if the element is already being served as a dependency, and during development the CLI will properly serve your project as a sibling of your dependencies.
 
 
-### `polymer build` {#build}
+#### Example: Building an App-Shell Application
 
-*This command is for app projects only.*
+`polymer init` offers several element templates to help you get started building a new application. [Polymer Starter Kit](https://github.com/PolymerElements/polymer-starter-kit) & [Shop](https://github.com/Polymer/shop) are two application templates already configured with an App-Shell architecture.
 
-Generates a production-ready build of your app. This process includes minifying the HTML, CSS, and
-JS of the application dependencies, and generating a service worker to pre-cache dependencies.
+If you're building an App-Shell application from scratch, make sure you create a [`polymer.json`](polymer-json) file for your project with `entrypoint`, `shell`, and `fragments` properties configured.
 
-Polymer CLI's build process is designed for apps that follow the [app shell
-architecture](https://developers.google.com/web/updates/2015/11/app-shell). To make sure your app
-builds properly, create a `polymer.json` file at the top-level of your project and store your
-build configurations there.
+Applications should also use relative URLs to import other source files and dependencies. But because applications are served independently, they can properly reach into the dependencies directory for dependencies.
 
-[See the polymer.json specification for more information](polymer-json).
-
-You can also pass equivalent values via the following command-line flags. This can be useful for
-building simple projects on your machine but you will need to include the flag every time you run
-the command. For most projects a `polymer.json` configuration file will be easier to work with and
-share across your team.
-
-* [`--add-service-worker`](#service-workers)
-* [`--bundle`](#bundles)
-* [`--css-minify`](#css-minify)
-* [`--entry`](#entrypoint)
-* [`--html-minify`](#html-minify)
-* [`--insert-prefetch-links`](#prefetch)
-* [`--js-compile`](#js-compile)
-* [`--js-minify`](#js-minify)
-* [`--shell`](#shell)
-* [`--fragment`](#fragment)
-
-#### `--add-service-worker` {#service-workers}
-
-Generate a service worker for your application to cache all files and assets on the client.
-
-Polymer CLI will generate a service worker for your build using the
-[sw-precache](https://github.com/GoogleChrome/sw-precache) library. To customize your service
-worker, create a `sw-precache-config.js` file in your project directory that exports your
-configuration. See the [sw-precache README](https://github.com/GoogleChrome/sw-precache) for a list
-of all supported options.
-
-Note that the sw-precache library uses a cache-first strategy for maximum speed and makes some
-other assumptions about how your service worker should behave. Read the
-["Considerations"](https://github.com/GoogleChrome/sw-precache#considerations) section of the
-sw-precache README to make sure that this is suitable for your application.
-
-#### `--bundle` {#bundles}
-
-By default, fragments are unbundled. This is optimal for HTTP/2-compatible servers and clients.
-
-If the `--bundle` flag is supplied, all fragments are bundled together to reduce the number of file
-requests. This is optimal for sending to clients or serving from servers that are not HTTP/2
-compatible.
-
-#### `--css-minify` {#css-minify}
-
-Minify inlined and external CSS.
-
-#### `--entry` {#entrypoint}
-
-A filename. This is the main entrypoint into your application for all routes. Often times this is
-your `index.html` file. This file should import the app shell file specified in the
-[`shell`](#shell) option. It should be minimal since it's loaded and cached for each route.
-
-#### `--html-minify` {#html-minify}
-
-Minify HTMl by removing comments and whitespace.
-
-#### `--insert-prefetch-links` {#prefetch}
-Insert prefetch link elements into your fragments so that all dependencies are prefetched
-immediately. Add dependency prefetching by inserting `<link rel="prefetch">` tags into entrypoint
-and `<link rel="import">` tags into fragments and shell for all dependencies.
-
-#### `--js-compile` {#js-compile}
-
-Use babel to compile all ES6 JS down to ES5 for older browsers.
-
-#### `--js-minify` {#js-minify}
-
-Minify inlined and external JavaScript.
-
-#### `--shell` {#shell}
-
-The app shell file containing common code for the app.
-
-#### `--fragment` {#fragment}
-
-This flag supports dynamic dependencies. It is an array of any HTML filenames that are not
-statically linked from the app shell (that is, imports loaded on demand by `importHref`).
-
-If a fragment has static dependencies, provided the fragment is defined in this property, the
-Polymer build analyzer will find them. You only need to list the file imported by importHref.
-
-In a Polymer app, the files listed in the fragments flag usually contain one or more element
-definitions that may or may not be required during the user’s interaction with the app, and can
-thus be lazily loaded.
-
-#### Examples {#examples}
-
-Create a bundled, minified application build:
-
-`polymer build --bundle --js-minify --css-minify --html-minify`
-
-Create an unbundled, minified application build:
-
-`polymer build --js-minify --css-minify --html-minify`
-
-## Manage dependencies {#dependencies}
-
-Polymer CLI uses [Bower](http://bower.io) for dependency management.
-
-Dependencies are stored in the `bower_components` directory. You should never manually alter the
-contents of this directory.
-
-Use the Bower CLI to manage dependencies.
-
-```bash
-# downloads dependency to bower_components/
-# --save flag saves new dependency to bower.json
-bower install --save PolymerElements/iron-ajax
-# removes dependency from bower_components/ and bower.json
-bower uninstall PolymerElements/iron-ajax
+```
+<!-- from a 'src/some-application.html' file in your application -->
+<link rel="import" href="../bower_components/polymer/polymer.html">
 ```
 
-## Global options {#global-options}
+Only one file should use absolute URLs for imports: your "entrypoint" (defaults to "index.html"). The reason is that in an App-Shell application your entrypoint is served for any URL so that your application loads on any URL. Because it can be served from anywhere, relative URLs are impossible. Use absolute URLs in the entrypoint instead.
 
-You can see a list of global options by running `polymer help`. Most of them
-are self-explanatory.
+```
+<!-- from a top-level application "entrypoint" -->
+<link rel="import" href="/bower_components/polymer/polymer.html">
+<link rel="import" href="/src/some-application.html">
+```
 
-The following commands are currently only supported for the `polymer build`
-command, with planned support for other commands in the future.
+#### Example: Deploying an Application
 
-*   `entry`
-*   `shell`
-*   `fragment`
-
-See [Build app](#build) for more information on how to use these options.
+When you're ready to deploy your application, check out the [Optimize for production](optimize-for-production) article for information about how to build your application for production.

--- a/app/2.0/docs/tools/polymer-json.md
+++ b/app/2.0/docs/tools/polymer-json.md
@@ -129,9 +129,7 @@ The `sources` property is set as follows:
 Optional<br>
 Type: `Array` of `Build Configuration` objects
 
-You can configure how the CLI builds your application via the `builds` property. This is equivalent
-to passing different CLI flags to the build command, but storing them here will configure the build
-for every run:
+You can configure how the CLI [builds your application for production](optimize-for-production) via the `builds` property. This is equivalent to passing different CLI flags to the build command, but storing them here will configure the build for every run:
 
 * `name`: An optional name for your build. If multiple builds are defined, the `name` property is
 required.

--- a/app/2.0/docs/tools/services.md
+++ b/app/2.0/docs/tools/services.md
@@ -1,5 +1,5 @@
 ---
-title: Services
+title: Web services
 ---
 
 <!-- toc -->

--- a/app/2.0/nav.yaml
+++ b/app/2.0/nav.yaml
@@ -117,7 +117,7 @@
 #  - title: Publish an element
 #    path: /2.0/docs/tools/reusable-elements
 #    indent: True
-  - title: Services
+  - title: Web services
     path: /2.0/docs/tools/services
     indent: True
   - title: polymer.json specification


### PR DESCRIPTION
For the Polymer Polish Party(tm) I went through the tooling documentation to look for anything that had gone out-of-date with our newest 1.0 tooling. I found and fixed everything out of date, clarified some confusing  bits, and moved some things to be less intimidating / easier to scan & read.

### Notable changes:
- `tools/overview.md`
  - Reword some wordy bits
- `tools/polymer-json.md`
  - Added link back to 'optimize-for-production.md' for builds config section
- **`tools/polymer-cli.md` *<-- biggest changes***
  - Currently: https://www.polymer-project.org/2.0/docs/tools/polymer-cli
  - Update deprecated installation instructions (git no longer needed, thank god)
  - Added an easy-to-grok overview to replace the pages of details about each command. The thinking is that those details are already found elsewhere on our docs site, the CLI repo README, and via the `polymer help COMMAND`. If more details are needed, pages like #2028 can focus on the actual use-case.
  - Focused instead on the more subtle assuptions that the CLI makes that aren't currently obvious in our docs: What app/element structures the CLI supports, relative vs. absolute paths, dependency paths, etc.
  - Added examples with info for element & app-shell applications
- `tools/services.md`
  - (Putting on my new user hat) I wasn't sure what "services" meant, so I renamed the section to "Web services" to be more clear that these are external web services.

---

@arthurevans @katejeffreys I'm happy to work you two to get this PR merged, but also won't be offended if you have your own plans for each of these docs. Even if that's the case hopefully there is something useful here you could use.