### PR TITLE
Added a note about slot multi-level distribution

### DIFF
--- a/app/2.0/docs/devguide/shadow-dom.md
+++ b/app/2.0/docs/devguide/shadow-dom.md
@@ -282,6 +282,9 @@ The ordering may be a little confusing at first. At each level, the light DOM ch
 slot `#parent-slot` in `<parent-element>`'s shadow DOM. The `#parent-slot` is then *assigned* to
 `#child-slot` in `<child-element>`'s shadow DOM.
 
+Note: these examples use `id` on slots for illustration purposes only.  This is not the same as
+the `name` attribute.  These slots are unnamed and are therefore default slots.
+
 The slot elements don't render, so the rendered tree is much simpler:
 
 

--- a/app/2.0/docs/devguide/shadow-dom.md
+++ b/app/2.0/docs/devguide/shadow-dom.md
@@ -282,8 +282,9 @@ The ordering may be a little confusing at first. At each level, the light DOM ch
 slot `#parent-slot` in `<parent-element>`'s shadow DOM. The `#parent-slot` is then *assigned* to
 `#child-slot` in `<child-element>`'s shadow DOM.
 
-Note: these examples use `id` on slots for illustration purposes only.  This is not the same as
+**Note:** This example uses `id` on slots for illustration purposes only.  This is not the same as
 the `name` attribute.  These slots are unnamed and are therefore default slots.
+{.alert .alert-info}
 
 The slot elements don't render, so the rendered tree is much simpler:
 


### PR DESCRIPTION
I was hung-up on `<slot id="x">` thinking it was `<slot name="x">` and thought maybe a note to remind user that the `id` is not the same as `name` might be useful for this example in particular.