### PR TITLE
Missing semi-colon

### DIFF
--- a/app/2.0/docs/devguide/shadow-dom.md
+++ b/app/2.0/docs/devguide/shadow-dom.md
@@ -470,7 +470,7 @@ shadow tree.
 ```
   #shadow-root
     <style>
-      :slotted(img) {
+      ::slotted(img) {
         border-radius: 100%;
       }
     </style>


### PR DESCRIPTION
Missing semi-colon from `slotted` pseudoelement in example.