### PR TITLE
Build-time highlighting. Fixes #2129. [Do Not Merge]

### DIFF
--- a/app/elements/pw-shell.html
+++ b/app/elements/pw-shell.html
@@ -441,12 +441,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.toggleClass('iron-selected', true, activeLink);
         this.styleLinkPath(activeLink, true);
       }
-
-      // Highlight any code bits that need to be highlighted.
-      var codeBlocks = Polymer.dom(this).querySelectorAll('pre code');
-      for (var i = 0; i < codeBlocks.length; i++) {
-        hljs.highlightBlock(codeBlocks[i]);
-      }
     },
 
     _handleSearchResponse: function(event) {

--- a/app/index.html
+++ b/app/index.html
@@ -312,15 +312,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <h2>Use elements from the catalog</h2>
         <div class="section-columns">
           <div class="example-code flex">
-            <pre><code class="lang-html">
-  &lt;!-- Polyfill Web Components support for older browsers --&gt;
-  &lt;script src=&quot;components/webcomponentsjs/webcomponents-lite.min.js&quot;&gt;&lt;/script&gt;
+            <pre><code class="html">
+  <!-- Polyfill Web Components support for older browsers -->
+  <script src="components/webcomponentsjs/webcomponents-lite.min.js"></script>
 
-  &lt;!-- Import element --&gt;
-  &lt;link rel=&quot;import&quot; href=&quot;components/google-map/google-map.html&quot;&gt;
+  <!-- Import element -->
+  <link rel="import" href="components/google-map/google-map.html">
 
-  &lt;!-- Use element --&gt;
-  &lt;google-map latitude=&quot;37.790&quot; longitude=&quot;-122.390&quot;&gt;&lt;/google-map&gt;
+  <!-- Use element -->
+  <google-map latitude="37.790" longitude="-122.390"></google-map>
           </code></pre>
           </div>
           <div class="example-google-map">
@@ -336,13 +336,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div class="section-columns">
           <div class="example-code flex">
             <pre><code class="lang-html">
-  &lt;dom-module id=&quot;contact-card&quot;&gt;
-    &lt;template&gt;
-      &lt;style&gt;...&lt;/style&gt;
-      &lt;slot&gt;&lt;/slot&gt;
-      &lt;iron-icon icon=&quot;star&quot; hidden$=&quot;{{!starred}}&quot;&gt;&lt;/iron-icon&gt;
-    &lt;/template&gt;
-    &lt;script&gt;
+  <dom-module id="contact-card">
+    <template>
+      <style>...</style>
+      <slot></slot>
+      <iron-icon icon="star" hidden$="{{!starred}}"></iron-icon>
+    </template>
+    <script>
       class ContactCard extends Polymer.Element {
         static get is() { return "contact-card"; }
         static get properties() {
@@ -352,15 +352,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
       }
       customElements.define(ContactCard.is, ContactCard);
-    &lt;/script&gt;
-  &lt;/dom-module&gt;
+    </script>
+  </dom-module>
             </code></pre>
             <br>
             <pre><code class="lang-html">
-  &lt;contact-card starred&gt;
-    &lt;img src=&quot;profile.jpg&quot; alt=&quot;Eric's photo&quot;&gt;
-    &lt;span&gt;Eric Bidelman&lt;/span&gt;
-  &lt;/contact-card&gt;
+  <contact-card starred>
+    <img src="profile.jpg" alt="Eric's photo">
+    <span>Eric Bidelman</span>
+  </contact-card>
             </code></pre>
           </div>
 
@@ -377,26 +377,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div class="section-columns">
           <div class="example-code flex">
             <pre><code class="lang-html">
-  &lt;iron-pages role="main" selected="[[page]]" attr-for-selected="name" selected-attribute="visible"&gt;
-    &lt;!-- home view --&gt;
-    &lt;shop-home name="home" categories="[[categories]]"&gt;&lt;/shop-home&gt;
+  <iron-pages role="main" selected="[[page]]" attr-for-selected="name" selected-attribute="visible">
+    <!-- home view -->
+    <shop-home name="home" categories="[[categories]]"></shop-home>
 
-    &lt;!-- list view of items in a category --&gt;
-    &lt;shop-list name="list" route="[[subroute]]" offline="[[offline]]"&gt;&lt;/shop-list&gt;
+    <!-- list view of items in a category -->
+    <shop-list name="list" route="[[subroute]]" offline="[[offline]]"></shop-list>
 
-    &lt;!-- detail view of one item --&gt;
-    &lt;shop-detail name="detail" route="[[subroute]]" offline="[[offline]]"&gt;&lt;/shop-detail&gt;
+    <!-- detail view of one item -->
+    <shop-detail name="detail" route="[[subroute]]" offline="[[offline]]"></shop-detail>
 
-    &lt;!-- cart view --&gt;
-    &lt;shop-cart name="cart" cart="[[cart]]" total="[[total]]"&gt;&lt;/shop-cart&gt;
+    <!-- cart view -->
+    <shop-cart name="cart" cart="[[cart]]" total="[[total]]"></shop-cart>
 
-    &lt;!-- checkout view --&gt;
-    &lt;shop-checkout
+    <!-- checkout view -->
+    <shop-checkout
         name="checkout"
         cart="[[cart]]"
         total="[[total]]"
-        route="{{subroute}}"&gt;&lt;/shop-checkout&gt;
-  &lt;/iron-pages&gt;
+        route="{{subroute}}"></shop-checkout>
+  </iron-pages>
             </code></pre>
           </div>
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "yargs": "^3.29.0"
   },
   "dependencies": {
-    "clone": "^2.1.0"
+    "clone": "^2.1.0",
+    "gulp-highlight": "^2.1.0"
   }
 }

--- a/templates/head-meta.html
+++ b/templates/head-meta.html
@@ -14,9 +14,6 @@
 
 <link rel="stylesheet" href="/css/site.css">
 
-<!-- Load hljs before pw-shell in elements.html tries to use it. -->
-<script src="/bower_components/highlight/highlight.js" async></script>
-
 <script>
   window.Polymer = window.Polymer || {dom: 'shadow', lazyRegister: true};
 </script>


### PR DESCRIPTION
Moves code highlighting for straight HTML pages to build time, like the MD pages.
Removes the 22K of highlightjs from page load, which is probably good.

Has one outstanding issue: even though we're using the same library under the hood (highlightjs), the gulp-highlight plugin appears to turn boolean attributes from `<foo-bar starred>` to `<foo-bar starred="">`. While not incorrect, it's ugly and I can't figure out which bit of code is responsible for it. Perhaps @keanulee has an idea here 

Also needs more testing. 

Staged for your amusement at https://highlight-em-dot-polymer-project.appspot.com/
