### PR TITLE
fix(first_element): fix documentation to use iron-icons.html

### DIFF
--- a/app/2.0/start/first-element/step-2.md
+++ b/app/2.0/start/first-element/step-2.md
@@ -32,7 +32,7 @@ Starting code—HTML imports { .caption }
 
 ```html
 <link rel="import" href="../polymer/polymer-element.html">
-<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../iron-icons/iron-icons.html">
 ```
 
 Key information:
@@ -223,7 +223,7 @@ icon-toggle.html { .caption }
 
 ```html
 <link rel="import" href="../polymer/polymer-element.html">
-<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../iron-icons/iron-icons.html">
 <dom-module id="icon-toggle">
   <template>
     <style>

--- a/app/2.0/start/first-element/step-4.md
+++ b/app/2.0/start/first-element/step-4.md
@@ -16,7 +16,7 @@ Import the `Polymer.GestureEventListeners` mixin by adding it to the HTML Import
 ```html
 <link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="../polymer/lib/mixins/gesture-event-listeners.html">
-<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../iron-icons/iron-icons.html">
 ```
 
 Use the mixin in the class declaration: 


### PR DESCRIPTION
iron-icon.html does not contain the definition for the polymer icon or
the star icon used in step 2 and step 4. This should be changed to use
iron-icons.html.

closes #2169