### PR TITLE
Fix import reference to polymer-element.html

### DIFF
--- a/app/2.0/start/toolbox/add-elements.md
+++ b/app/2.0/start/toolbox/add-elements.md
@@ -30,7 +30,7 @@ Run this command from your project root directory:
 
 1.  Import `paper-checkbox.html` as a dependency.
 
-    Add this import beneath the existing import for `polymer.html`:
+    Add this import beneath the existing import for `polymer-element.html`:
 
     ```
     <link rel="import" href="../bower_components/paper-checkbox/paper-checkbox.html">


### PR DESCRIPTION
The tutorial refers to a non-existent import of _polymer.html_ instead of the actual _polymer-element.html_ import.