### PR TITLE
Remove mention of the "next" version of Polymer CLI from upgrade.md

### DIFF
--- a/app/2.0/docs/upgrade.md
+++ b/app/2.0/docs/upgrade.md
@@ -64,7 +64,7 @@ Before you start the upgrade, there's a couple of things you need to do.
 *   Create a new branch or workspace.
 *   Update bower dependencies.
 
-Update the Polymer CLI to the `next` version:
+Update the Polymer CLI:
 
 ```
 npm update polymer-cli


### PR DESCRIPTION
The command for updating Polymer CLI previously had the `@next` suffix, but since it's not used anymore, also remove the mention of the `next` version from the paragraph above the command.