### PR TITLE
Clarify definition of custom property mixins

### DIFF
--- a/app/2.0/docs/devguide/shadow-dom.md
+++ b/app/2.0/docs/devguide/shadow-dom.md
@@ -537,7 +537,7 @@ background-color: var(--my-theme-color, var(--another-theme-color, blue));
 ### Custom property mixins
 
 Custom property *mixins* are a feature built on top of the custom property specification. Basically,
-the mixin is a custom property that takes an object value:
+the mixin is a variable that contains multiple properties:
 
 
 ```


### PR DESCRIPTION
Mixins do not take an actual JS object, and the word "take" makes it seem more like a JS function that 'takes' a parameter so that definition is a little misleading.  Of course, the given example proves this to NOT be the case, but I think this is clearer anyway.