### PR TITLE
Add resolutions for hybrid iron-doc-viewer.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,8 @@
     "firebase-element": "PolymerElements/firebase-element#^1.0.12"
   },
   "resolutions": {
+    "iron-location": "1 - 2",
+    "app-route": "1 - 2",
     "iron-doc-viewer": "2.0-analyzer"
   }
 }


### PR DESCRIPTION
https://github.com/PolymerElements/iron-doc-viewer/pull/134 updates the iron-doc-viewer bower config to be hybrid. The docs site needs a few resolutions.