### PR TITLE
Docs: Show builds in example polymer.json

### DIFF
--- a/app/2.0/docs/tools/polymer-json.md
+++ b/app/2.0/docs/tools/polymer-json.md
@@ -59,7 +59,11 @@ Here’s an example `polymer.json` file from the [Shop app](https://github.com/P
   ],
   "lint": {
     "rules": ["polymer-2-hybrid"]
-  }
+  },
+  "builds": [
+    { "preset": "es5-bundled" },
+    { "preset": "es6-unbundled" }
+  ]
 }
 ```
 


### PR DESCRIPTION
Shop App has build presets in its `polymer.json`

Also, it is a good overview of all the main parts of the `polymer.json`