### PR TITLE
add static getter is to the custom element class

### DIFF
--- a/app/2.0/docs/devguide/registering-elements.md
+++ b/app/2.0/docs/devguide/registering-elements.md
@@ -17,7 +17,7 @@ Example: { .caption }
 ```
 // define the element's class element
 class MyElement extends Polymer.Element {
-
+  static get is() { return 'my-element'; }
   // Element class can define custom element reactions
   connectedCallback() {
     super.connectedCallback();


### PR DESCRIPTION
As the doc reads:  
> The class must have a static `is` getter that returns the HTML tag name for your custom element.