### PR TITLE
Set cache-control header for SW to 1s

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -45,6 +45,7 @@ handlers:
   static_files: service-worker.js
   upload: service-worker.js
   secure: always
+  expiration: "1s" # "0s" doesn't work
 
 # Special exception for the summit site so it doesn't require
 # a trailing slash


### PR DESCRIPTION
Currently all static assets are cached for 10 minutes (App Engine default -
 https://cloud.google.com/appengine/docs/standard/python/config/appref#default_expiration). This adds an exception for the SW since it should be updated as soon as possible (https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/lifecycle#updates)

Staged at https://service-worker-dot-polymer-project.appspot.com/