### PR TITLE
Upgrade old css selector

### DIFF
--- a/app/2.0/docs/devguide/custom-css-properties.md
+++ b/app/2.0/docs/devguide/custom-css-properties.md
@@ -488,7 +488,7 @@ The custom properties shim doesn't support styling distributed elements.
 
 ```css
 /* Not supported */
-:host ::slotted(*) div {
+:host ::slotted(div) {
   --custom-color: red;
 }
 ```

--- a/app/2.0/docs/devguide/custom-css-properties.md
+++ b/app/2.0/docs/devguide/custom-css-properties.md
@@ -488,7 +488,7 @@ The custom properties shim doesn't support styling distributed elements.
 
 ```css
 /* Not supported */
-:host ::content div {
+:host ::slotted(*) div {
   --custom-color: red;
 }
 ```


### PR DESCRIPTION
`::content` selector belongs to Polymer 1.x  and it has been upgrade to `::slotted()` selector in Polymer 2 , according to the [official upgrade doc](https://www.polymer-project.org/2.0/docs/upgrade).