### PR TITLE
Add "this" argument to ShadyCSS.getComputedStyleValue()

### DIFF
--- a/app/2.0/docs/devguide/custom-css-properties.md
+++ b/app/2.0/docs/devguide/custom-css-properties.md
@@ -360,7 +360,7 @@ slightly differently depending on whether the shady CSS polyfill is loaded:
 
 ```js
 if (ShadyCSS) {
-  style = ShadyCSS.getComputedStyleValue('--something');
+  style = ShadyCSS.getComputedStyleValue(this, '--something');
 } else {
   style = getComputedStyle(this, '--something');
 }


### PR DESCRIPTION
I think that the `this` argument is necessary to make this work.