### PR TITLE
Array mutations not tracked in data bindings

### DIFF
--- a/app/2.0/docs/devguide/data-binding.md
+++ b/app/2.0/docs/devguide/data-binding.md
@@ -524,6 +524,9 @@ item**.
 <span>{{array.0}}</span>
 ```
 
+**Array binding does not track array mutations.** 
+An array mutation that reorders an array (for example, using the [splice method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice)) will not be reflected in static bindings.
+{ .alert .alert-info }
 
 There are several ways to interact with arrays in a data binding:
 

--- a/app/2.0/docs/devguide/data-binding.md
+++ b/app/2.0/docs/devguide/data-binding.md
@@ -518,15 +518,11 @@ To keep annotation parsing simple, **Polymer doesn't provide a way to bind direc
 item**.
 
 ```
-<!-- Don't do this! -->
-<span>{{array[0]}}</span>
-<!-- Or this! -->
-<span>{{array.0}}</span>
+<!-- Don't do this! This format doesn't work -->
+<span>[[array[0]]]</span>
+<!-- Don't do this! Data may display, but won't be updated correctly -->
+ <span>[[array.0]]</span>
 ```
-
-**Array binding does not track array mutations.** 
-An array mutation that reorders an array (for example, using the [splice method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice)) will not be reflected in static bindings.
-{ .alert .alert-info }
 
 There are several ways to interact with arrays in a data binding:
 

--- a/app/2.0/docs/devguide/data-binding.md
+++ b/app/2.0/docs/devguide/data-binding.md
@@ -519,9 +519,9 @@ item**.
 
 ```
 <!-- Don't do this! This format doesn't work -->
-<span>[[array[0]]]</span>
+<span>{{array[0]}}</span>
 <!-- Don't do this! Data may display, but won't be updated correctly -->
- <span>[[array.0]]</span>
+ <span>{{array.0}}</span>
 ```
 
 There are several ways to interact with arrays in a data binding:


### PR DESCRIPTION
Array mutations are not tracked and won't reflect in static bindings. Add note to that effect.

Fixes #2228