### PR TITLE
added quick fixes to the quick tour

### DIFF
--- a/app/2.0/start/toolbox/add-elements.md
+++ b/app/2.0/start/toolbox/add-elements.md
@@ -22,7 +22,7 @@ In this step, you'll add Polymer's `<paper-checkbox>` element to your app, which
 
 Run this command from your project root directory:
 
-    bower install --save PolymerElements/paper-checkbox#2.0-preview
+    bower install --save PolymerElements/paper-checkbox
 
 ## Add the element to your application
 

--- a/app/2.0/start/toolbox/create-a-page.md
+++ b/app/2.0/start/toolbox/create-a-page.md
@@ -106,7 +106,7 @@ you need to add it to your app's HTML.
     The following code that came with the app template will ensure the
     definition for each page has been loaded when the route changes.  As
     you can see, the app follows a simple convention (`'my-' + page + '.html'`)
-    when importing the definition for each route,. You can adapt this code as you
+    when importing the definition for each route. You can adapt this code as you
     like to handle more complex routing and lazy loading.
 
     Existing template code—you do not need to add this { .caption }

--- a/app/2.0/start/toolbox/set-up.md
+++ b/app/2.0/start/toolbox/set-up.md
@@ -13,21 +13,19 @@ App Toolbox template in less than 15 minutes.
 
 ## Install Polymer CLI
 
-Polymer CLI is an all-in-one command line tool for Polymer projects. In this tutorial you use 
-Polymer CLI to initialize, serve, and build your project. You can also use it for linting and 
+Polymer CLI is an all-in-one command line tool for Polymer projects. In this tutorial you use
+Polymer CLI to initialize, serve, and build your project. You can also use it for linting and
 testing, but this tutorial won't cover those topics.
 
-Polymer CLI requires Node.js, npm, Git and Bower. For full installation instructions, see [the 
+Polymer CLI requires Node.js, npm, Git and Bower. For full installation instructions, see [the
 Polymer CLI documentation](/{{{polymer_version_dir}}}/docs/tools/polymer-cli).
 
 To install Polymer CLI:
 
-   ```bash
    npm install -g polymer-cli
-   ```
+
 
 ## Initialize your project from a template
-
 1. Create a new project folder to start from.
 
         mkdir my-app
@@ -35,7 +33,11 @@ To install Polymer CLI:
 
 1. Initialize your project with an app template.
 
-        polymer init polymer-2-starter-kit
+        polymer init
+
+    Press the down arrow until `polymer-2-starter-kit` is highlighted and press the enter / return
+    key to select.
+
 
 ## Serve your project
 


### PR DESCRIPTION
* messed with the highlighting of the commands so all the terminal commands are the same color.
* removed an old 2.0-preview bower install

```
-        polymer init polymer-2-starter-kit
```

changed to 

```
+        polymer init
+
+    Press the down arrow until `polymer-2-starter-kit` is highlighted and press the enter / return
+    key to select.
```

lmk how that sits with y'all