### PR TITLE
UPT: Typo web site year

### DIFF
--- a/app/elements/pw-footer.html
+++ b/app/elements/pw-footer.html
@@ -175,7 +175,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       <div class="copyright layout horizontal">
         <div class="flex">
-          &copy; 2016 Polymer Authors.
+          &copy; 2017 Polymer Authors.
           <span class="additional-text">Code Licensed under the BSD License. Documentation licensed under CC BY 3.0.<span>
         </div>
         <a href="#" on-click="_smoothScrollToTop">


### PR DESCRIPTION
The footer of polymer homepage seems not update in this year.