### PR TITLE
Quote page titles.

### DIFF
--- a/app/blog/2017-05-17-summit-2017.md
+++ b/app/blog/2017-05-17-summit-2017.md
@@ -1,5 +1,5 @@
 ---
-title: Polymer Summit 2017: Wonderful Copenhagen
+title: "Polymer Summit 2017: Wonderful Copenhagen"
 ---
 
 **Update: Registration is now open.** Register for free for your spot at the [2017 Polymer Summit](https://events.withgoogle.com/polymer-summit-2017/registrations/new/)

--- a/app/blog/2017-07-31-speaker-spotlight-josh.md
+++ b/app/blog/2017-07-31-speaker-spotlight-josh.md
@@ -1,5 +1,5 @@
 ---
-title: Polymer Summit 2017 Speaker Spotlight: Josh Trout, Gannett
+title: "Polymer Summit 2017 Speaker Spotlight: Josh Trout, Gannett"
 ---
 
 Josh is a principal developer on the web team at Gannett. We chatted with Josh about Polymer, the Web, and building apps for the future.


### PR DESCRIPTION
Avoids an issue where the HTML page title (that shows up in the browser tab, for example) doesn't get set because the colon in the title throws off the YAML parser.