### PR TITLE
Add plunker analytics

### DIFF
--- a/app/2.0/start/quick-tour.md
+++ b/app/2.0/start/quick-tour.md
@@ -30,7 +30,7 @@ an element name with a class, so you can add properties and methods to your cust
 element. The custom element's name **must start with an ASCII letter and
 contain a dash (-)**.
 
-<demo-tabs selected="0" src="http://plnkr.co/edit/ScvcB4?p=preview">
+<demo-tabs selected="0" name="qt-1-register" src="http://plnkr.co/edit/ScvcB4?p=preview">
   <demo-tab heading="custom-element.html">
 <pre><code>{{{include_file('2.0/start/samples/custom-element/custom-element.html')}}}</code></pre>
   </demo-tab>
@@ -59,7 +59,7 @@ You can use the `ready` callback for one-time initialization work after the elem
 Many elements include some internal DOM nodes to implement the element's UI and behavior.
 You can use Polymer's DOM templating to create a shadow DOM tree for your element.
 
-<demo-tabs selected="0" src="http://plnkr.co/edit/DaiLYY?p=preview">
+<demo-tabs selected="0" name="qt-2-shadow-dom" src="http://plnkr.co/edit/DaiLYY?p=preview">
   <demo-tab heading="dom-element.html">
 <pre><code>{{{include_file('2.0/start/samples/dom-element/dom-element.html')}}}</code></pre>
   </demo-tab>
@@ -82,7 +82,7 @@ so they render as if they were inserted into the shadow DOM tree.
 This example creates a simple tag that decorates an image by wrapping it
 with a styled `<div>` tag.
 
-<demo-tabs selected="0" src="http://plnkr.co/edit/BzgJBN?p=preview">
+<demo-tabs selected="0" name="qt-3-compose" src="http://plnkr.co/edit/BzgJBN?p=preview">
   <demo-tab heading="picture-frame.html">
 <pre><code>{{{include_file('2.0/start/samples/picture-frame/picture-frame.html')}}}</code></pre>
   </demo-tab>
@@ -109,7 +109,7 @@ Data binding is a great way to quickly propagate changes in your element and red
 You can bind properties in your component using the "double-mustache" syntax (`{%raw%}{{}}{%endraw%}`).
 The `{%raw%}{{}}{%endraw%}` is replaced by the value of the property referenced between the brackets.
 
-<demo-tabs selected="0" src="http://plnkr.co/edit/8mZK8S?p=preview">
+<demo-tabs selected="0" name="qt-4-data-binding" src="http://plnkr.co/edit/8mZK8S?p=preview">
   <demo-tab heading="name-tag.html">
 <pre><code>{{{include_file('2.0/start/samples/name-tag/name-tag.html')}}}</code></pre>
   </demo-tab>
@@ -132,7 +132,7 @@ values, configuring properties from markup, observing property changes, and more
 The following example declares the `owner` property from the last example.
 It also shows configuring the owner property from markup in `index.html`.
 
-<demo-tabs selected="0" src="http://plnkr.co/edit/ROIvZg?p=preview">
+<demo-tabs selected="0" name="qt-5-declare-property" src="http://plnkr.co/edit/ROIvZg?p=preview">
   <demo-tab heading="configurable-name-tag.html">
 <pre><code>{{{include_file('2.0/start/samples/configurable-name-tag/configurable-name-tag.html')}}}</code></pre>
   </demo-tab>
@@ -155,7 +155,7 @@ can optionally support two-way binding, using curly braces (`property-name="{{bi
 This example uses two-way binding: binding the value of a custom input element (`iron-input`)
 to the element's `owner` property, so it's updated as the user types.
 
-<demo-tabs selected="0" src="http://plnkr.co/edit/VYR8my?p=preview">
+<demo-tabs selected="0" name="qt-6-bind-property" src="http://plnkr.co/edit/VYR8my?p=preview">
   <demo-tab heading="editable-name-tag.html">
 <pre><code>{{{include_file('2.0/start/samples/editable-name-tag/editable-name-tag.html')}}}</code></pre>
   </demo-tab>
@@ -174,7 +174,7 @@ data binding and input validation.
 
 The template repeater (`dom-repeat`) is a specialized template that binds to an array. It creates one instance of the template's contents for each item in the array.
 
-<demo-tabs selected="0" src="http://plnkr.co/edit/FdgkAtcLFHX5TpTsYtZn?p=preview">
+<demo-tabs selected="0" name="qt-7-dom-repeat" src="http://plnkr.co/edit/FdgkAtcLFHX5TpTsYtZn?p=preview">
   <demo-tab heading="employee-list.html">
 <pre><code>{{{include_file('2.0/start/samples/employee-list/employee-list.html')}}}</code></pre>
   </demo-tab>

--- a/app/elements/demo-tabs.html
+++ b/app/elements/demo-tabs.html
@@ -84,7 +84,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </template>
       </paper-tabs>
       <a href="[[src]]" target="_blank" hidden$="[[_hidePlunkrButton(src)]]">
-        <paper-button raised>
+        <paper-button on-click="_plunkerLaunched" raised>
           <iron-icon icon="pw-icons:exit-to-app"></iron-icon>
           Edit on Plunker
         </paper-button>
@@ -112,6 +112,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       src: {
         type: String
+      },
+      /**
+       * Name of the demo, for analytics
+       */
+      name: {
+        type: String
       }
     },
 
@@ -133,6 +139,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _hidePlunkrButton: function(src) {
       return (!src || src === '');
+    },
+
+    // Call out to a global method defined by app.js
+    _plunkerLaunched: function() {
+      console.log("Launch plunker "+this.name);
+      if (window.recordPlunker) {
+        window.recordPlunker(this.name);
+      }
     }
   });
   </script>

--- a/app/elements/demo-tabs.html
+++ b/app/elements/demo-tabs.html
@@ -143,7 +143,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     // Call out to a global method defined by app.js
     _plunkerLaunched: function() {
-      console.log("Launch plunker "+this.name);
       if (window.recordPlunker) {
         window.recordPlunker(this.name);
       }

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -49,6 +49,10 @@ function downloadStarter() {
   ga('send', 'event', 'button', 'download');
 }
 
+function recordPlunker(demo) {
+  ga('send', 'event', 'plunker', demo);
+}
+
 function recordSearch(term) {
   ga('send', 'event', 'search', term);
 }
@@ -62,6 +66,7 @@ function recordPageview(opt_url) {
 exports.recordPageview = recordPageview;
 exports.recordSearch = recordSearch;
 exports.downloadStarter = downloadStarter;
+exports.recordPlunker = recordPlunker;
 
 // Analytics -----
 /* jshint ignore:start */


### PR DESCRIPTION
Adds an analytics event when the user clicks on the Plunker button on a demo tab. Adds a `name` property to the `demo-tab` element.  Logs an analytics event with event category: "plunker", and the demo name as the event action.
