### PR TITLE
`!/__/**` rewrite is unnecessary and breaks things

### DIFF
--- a/app/2.0/start/toolbox/deploy.md
+++ b/app/2.0/start/toolbox/deploy.md
@@ -186,10 +186,6 @@ guide](https://www.firebase.com/docs/hosting/quickstart.html).
         "public": "build/es5-bundled/",
         "rewrites": [
           {
-            "source": "!/__/**",
-            "destination": "/index.html"
-          },
-          {
             "source": "**/!(*.js|*.html|*.css|*.json|*.svg|*.png|*.jpg|*.jpeg)",
             "destination": "/index.html"
           }


### PR DESCRIPTION
According to the [Firebase Hosting docs](https://firebase.google.com/docs/hosting/url-redirects-rewrites#section-priorities) the reserved `/__/**` urls will always have priority so rewriting them isn't necessary.

And since this rewrite rule is more or less a catch-all, it will already trigger for everything before the second rule can take effect.

In a normal Polymer app this means that trying to access https://my-app.firebaseapp.com/doesnotexist will try to load `src/my-doesnotexist.html` which gets rewritten to index.html and therefore doesn't trigger the 404 fallback.