### PR TITLE
Update dead link to correct guide

### DIFF
--- a/app/2.0/docs/upgrade.md
+++ b/app/2.0/docs/upgrade.md
@@ -1509,7 +1509,7 @@ features from `MyMixin`. So `MyElement`'s inheritance is:
 `MyElement => MyMixin(Polymer.Element) => Polymer.Element`
 
 For information on writing your own class expression mixins, see
-[Sharing code with class expression mixins](#mixins)
+[Sharing code with class expression mixins](devguide/custom-elements#mixins)
 
 
 #### Using hybrid behaviors with class-style elements


### PR DESCRIPTION
The original anchor did not exist and I think it was meant to target https://www.polymer-project.org/2.0/docs/devguide/custom-elements#mixins