### PR TITLE
Update firebase deploy instructions

### DIFF
--- a/app/1.0/start/toolbox/deploy.md
+++ b/app/1.0/start/toolbox/deploy.md
@@ -132,23 +132,25 @@ guide](https://www.firebase.com/docs/hosting/quickstart.html).
     build your application, Polymer CLI places your bundled application
     appropriate for serving on Firebase into the `build/bundled` folder.
 
-1.  Edit your firebase configuration to add support for URL routing.  Add
-    the following section to your `firebase.json` file, which will instruct
-    Firebase to serve up `index.html` for any URL's that don't otherwise
-    end in a file extension.
-
+1.  Edit your firebase configuration to add support for URL routing. The final
+    `firebase.json` file should look something like this:
+	
     ```
-    "rewrites": [
-      {
-        "source": "!/__/**",
-        "destination": "/index.html"
-      },
-      {
-        "source": "**/!(*.js|*.html|*.css|*.json|*.svg|*.png|*.jpg|*.jpeg)",
-        "destination": "/index.html"
+    {
+      "hosting": {
+        "public": "build/es5-bundled/",
+        "rewrites": [
+          {
+            "source": "**/!(*.*)",
+            "destination": "/index.html"
+          }
+        ]
       }
-    ]
-    ```
+    }
+    ```	
+
+    This instructs Firebase to serve up `index.html` for any URLs that don't
+    otherwise end in a file extension.
 
 1.  Deploy.
 

--- a/app/1.0/start/toolbox/deploy.md
+++ b/app/1.0/start/toolbox/deploy.md
@@ -138,7 +138,7 @@ guide](https://www.firebase.com/docs/hosting/quickstart.html).
     ```
     {
       "hosting": {
-        "public": "build/es5-bundled/",
+        "public": "build/bundled/",
         "rewrites": [
           {
             "source": "**/!(*.*)",

--- a/app/2.0/start/toolbox/deploy.md
+++ b/app/2.0/start/toolbox/deploy.md
@@ -159,38 +159,16 @@ guide](https://www.firebase.com/docs/hosting/quickstart.html).
 
 1.  Firebase asks you the name of your app's public folder. Enter `build/es5-bundled/`.
 
-1.  Edit your firebase configuration to add support for URL routing.  Add
-    the following to the `hosting` object in your `firebase.json` file.
-
-    ```
-    "rewrites": [
-      {
-        "source": "!/__/**",
-        "destination": "/index.html"
-      },
-      {
-        "source": "**/!(*.js|*.html|*.css|*.json|*.svg|*.png|*.jpg|*.jpeg)",
-        "destination": "/index.html"
-      }
-    ]
-    ```
-
-    For example, your `firebase.json` file may look like this afterwards:
+1.  Edit your firebase configuration to add support for URL routing. The final
+    `firebase.json` file should look something like this:
 	
     ```
     {
-      "database": {
-        "rules": "database.rules.json"
-      },
       "hosting": {
         "public": "build/es5-bundled/",
         "rewrites": [
           {
-            "source": "!/__/**",
-            "destination": "/index.html"
-          },
-          {
-            "source": "**/!(*.js|*.html|*.css|*.json|*.svg|*.png|*.jpg|*.jpeg)",
+            "source": "**/!(*.*)",
             "destination": "/index.html"
           }
         ]

--- a/app/2.0/start/toolbox/deploy.md
+++ b/app/2.0/start/toolbox/deploy.md
@@ -105,6 +105,11 @@ and create a new project.
       upload: build/es5-bundled/manifest.json
       secure: always
 
+    - url: /service-worker.js
+      static_files: build/es5-bundled/service-worker.js
+      upload: build/es5-bundled/service-worker.js
+      secure: always
+
     - url: /.*
       static_files: build/es5-bundled/index.html
       upload: build/es5-bundled/index.html


### PR DESCRIPTION
The rewrite rule for `!/__/**` is unnecessary since Firebase Hosting already handles those URLs without any configuration (see https://firebase.google.com/docs/hosting/url-redirects-rewrites#section-priorities). Moreover, this results in URLs with extensions (like /src/my-nonexistent-view.html) to incorrectly rewrite to index.html and causes issues like https://github.com/PolymerElements/polymer-starter-kit/issues/1061.

(The `!/__/**` rule was first added in https://github.com/Polymer/docs/pull/1815)