### PR TITLE
Change to contact card example

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -367,7 +367,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         static get is() { return "contact-card"; }
         static get properties() {
           return {
-            starred: { type: Boolean, value: true }
+            starred: { type: Boolean, value: false }
           }
         }
       }


### PR DESCRIPTION
This is about the contact card example on the landing page (https://www.polymer-project.org/).

It's under the "Create your own elements" headline:
```JS
static get properties() {
  return {
    starred: { type: Boolean, value: true} // <-- Value should be false
  }
}
```
"For a Boolean property to be configurable from markup, it must default to false. If it defaults to true, you cannot set it to false from markup [...]" Source: https://www.polymer-project.org/2.0/docs/devguide/properties#configuring-boolean-properties

The example should be fixed to show idiomatic Polymer.