### PR TITLE
Remove promise polyfill.

### DIFF
--- a/app/elements/pw-shell.html
+++ b/app/elements/pw-shell.html
@@ -13,8 +13,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../bower_components/app-layout/app-header/app-header.html">
 <link rel="import" href="../bower_components/app-route/app-location.html">
 <link rel="import" href="../bower_components/app-route/app-route.html">
-<!-- promise polyfill required by iron-ajax 2.0 -->
-<link rel="import" href="../bower_components/promise-polyfill/promise-polyfill-lite.html">
 <link rel="import" href="../bower_components/iron-ajax/iron-ajax.html">
 <link rel="import" href="../bower_components/iron-media-query/iron-media-query.html">
 <link rel="import" href="../bower_components/iron-flex-layout/iron-flex-layout-classes.html">

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,6 @@
     "paper-listbox": "PolymerElements/paper-listbox#2",
     "paper-tabs": "PolymerElements/paper-tabs#2",
     "paper-toast": "PolymerElements/paper-toast#2",
-    "promise-polyfill": "polymerlabs/promise-polyfill#2",
     "google-youtube": "GoogleWebComponents/google-youtube#2",
     "google-map": "GoogleWebComponents/google-map#2",
     "web-animations-js": "web-animations/web-animations-js#^2.2.5"


### PR DESCRIPTION
Remove the promise polyfill, added to support iron-ajax in 1.x hybrid mode.

Shouldn't be required now, since promise is part of the v1 WC polyfills.

Staged at: https://2017-10-04-no-promises-dot-polymer-project.appspot.com