### PR TITLE
No template[is=dom-repeat], especially document-level

### DIFF
--- a/app/elements/demo-tabs.html
+++ b/app/elements/demo-tabs.html
@@ -79,9 +79,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div class="tabstrip layout horizontal center">
       <paper-tabs selected="{{_selected}}" class="flex">
-        <template is="dom-repeat" items="[[_panels]]">
-          <paper-tab>{{item.heading}}</paper-tab>
-        </template>
+        <dom-repeat items="[[_panels]]">
+          <template>
+            <paper-tab>{{item.heading}}</paper-tab>
+          </template>
+        </dom-repeat>
       </paper-tabs>
       <a href="[[src]]" target="_blank" hidden$="[[_hidePlunkrButton(src)]]">
         <paper-button on-click="_plunkerLaunched" raised>

--- a/app/elements/pw-shell.html
+++ b/app/elements/pw-shell.html
@@ -435,7 +435,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         // Populate the results in the dom-repeat.
-        section.querySelector('template').items = response.items;
+        section.querySelector('#searchResults').items = response.items;
 
         // Previous and Next buttons.
         queryPrefix += '&start=';

--- a/app/search/index.html
+++ b/app/search/index.html
@@ -101,13 +101,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </div>
           <br><br>
 
-          <template is="dom-repeat">
-            <div class="search-result">
-              <span class="search-label" data-label$="{{item.label}}">{{item.label}}</span>
-              <a href="{{item.link}}">{{item.title}}</a>
-              <p class="snippet">{{item.snippet}}</p>
-            </div>
-          </template>
+          <dom-repeat id="searchResults">
+            <template>
+              <div class="search-result">
+                <span class="search-label" data-label$="{{item.label}}">{{item.label}}</span>
+                <a href="{{item.link}}">{{item.title}}</a>
+                <p class="snippet">{{item.snippet}}</p>
+              </div>
+            </template>
+          </dom-repeat>
 
           <div class="results-button-container">
             <a href="" class="previous-results blue-button">Previous page</a>


### PR DESCRIPTION
This fixes the empty search results page. This change has already been deployed.