### PR TITLE
Fix search results in shady dom

### DIFF
--- a/app/elements/lazy-elements.html
+++ b/app/elements/lazy-elements.html
@@ -21,3 +21,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="iron-doc-viewer.html">
 <link rel="import" href="demo-tabs.html">
 <link rel="import" href="pw-version-selector.html">
+<link rel="import" href="pw-search-results.html">

--- a/app/elements/pw-search-results.html
+++ b/app/elements/pw-search-results.html
@@ -1,0 +1,67 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<dom-module id="pw-search-results">
+  <template>
+    <style>
+      .search-result {
+        margin-bottom: 20px;
+      }
+
+      .search-label {
+        color: white;
+        padding: 5px 10px;
+        text-align: center;
+        font-weight: bold;
+        border-radius: 3px;
+      }
+
+      .search-label[data-label="1.0"] {
+        background-color: #37474f;
+      }
+
+      .search-label[data-label="2.0"] {
+        background-color: #1565c0;
+      }
+
+      .search-label[data-label="Blog"] {
+        background-color: #e8345a;
+      }
+
+      .search-label[data-label="all"] {
+        color: black;
+      }
+    </style>
+
+    <dom-repeat items="[[items]]">
+      <template>
+        <div class="search-result">
+          <span class="search-label" data-label$="[[item.label]]">[[item.label]]</span>
+          <a href="[[item.link]]">[[item.title]]</a>
+          <p class="snippet">[[item.snippet]]</p>
+        </div>
+      </template>
+    </dom-repeat>
+  </template>
+
+  <script>
+  Polymer({
+    is: 'pw-search-results',
+
+    properties: {
+      /**
+       * Search result items.
+       */
+      items: {
+        type: Object
+      }
+    }
+  });
+  </script>
+</dom-module>

--- a/app/elements/pw-shell.html
+++ b/app/elements/pw-shell.html
@@ -122,6 +122,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         box-sizing: border-box;
         -webkit-transform: translate3d(100%, 0, 0);
         transform: translate3d(100%, 0, 0);
+        -webkit-appearance: none;
       }
 
       .search-box:focus {
@@ -162,7 +163,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         <nav>
           <iron-selector class="sections-tabs" attr-for-selected="name" activate-event="" selected="[[_computeSection(path)]]">
-
             <a href="/1.0/start/" name="1.0/start" data-version="1.0">Start</a>
             <a href="/1.0/docs/devguide/feature-overview" name="1.0/docs" data-version="1.0">Polymer</a>
             <a href="/1.0/toolbox/" name="1.0/toolbox" data-version="1.0">App Toolbox</a>

--- a/app/search/index.html
+++ b/app/search/index.html
@@ -33,18 +33,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         font-weight: bold;
       }
 
-      .search-result {
-        margin-bottom: 20px;
-      }
-
-      .search-label {
-        color: white;
-        padding: 5px 10px;
-        text-align: center;
-        font-weight: bold;
-        border-radius: 3px;
-      }
-
       a.search-filter {
         padding: 0 10px;
         display: inline-block;
@@ -53,22 +41,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       a.search-filter.active {
         color: #f50057;
-      }
-
-      .search-label[data-label="1.0"] {
-        background-color: #37474f;
-      }
-
-      .search-label[data-label="2.0"] {
-        background-color: #1565c0;
-      }
-
-      .search-label[data-label="Blog"] {
-        background-color: #e8345a;
-      }
-
-      .search-label[data-label="all"] {
-        color: black;
       }
 
       .results-button-container {
@@ -101,15 +73,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </div>
           <br><br>
 
-          <dom-repeat id="searchResults">
-            <template>
-              <div class="search-result">
-                <span class="search-label" data-label$="{{item.label}}">{{item.label}}</span>
-                <a href="{{item.link}}">{{item.title}}</a>
-                <p class="snippet">{{item.snippet}}</p>
-              </div>
-            </template>
-          </dom-repeat>
+          <pw-search-results id="searchResults"></pw-search-results>
 
           <div class="results-button-container">
             <a href="" class="previous-results blue-button">Previous page</a>


### PR DESCRIPTION
I noticed that the search results don't show on Shady DOM (e.g. Firefox) if you initiate a search from outside the search page (e.g. the homepage). This should fix it. I made a separate `<pw-search-results>` element that is lazy-loaded because eventually I want to move some of the search logic from `<pw-shell>` here; for now this just fixes a more pressing issue.

Staged at https://2017-10-12-search-dot-polymer-project.appspot.com