### PR TITLE
Search element

### DIFF
--- a/app/elements/pw-search-results.html
+++ b/app/elements/pw-search-results.html
@@ -10,6 +10,62 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="pw-search-results">
   <template>
     <style>
+      :host {
+        display: block;
+      }
+
+      .yes-query {
+        display: none;
+      }
+
+      [query] .no-query {
+        display: none;
+      }
+
+      [query] .yes-query {
+        display: block;
+      }
+
+      .no-results {
+        display: none;
+      }
+
+      [no-results] .no-results {
+        display: block;
+      }
+
+      .search-query {
+        color: #1e87ea !important;
+      }
+
+      .search-query.small {
+        color: black;
+        font-weight: bold;
+      }
+
+      a {
+        color: #1e88e5;
+        text-decoration: none;
+        font-weight: 500;
+      }
+
+      a:hover {
+        text-decoration: underline;
+      }
+
+      a.search-filter {
+        padding: 0 10px;
+        display: inline-block;
+        cursor: pointer;
+      }
+
+      [active-label="1.0"] a.search-filter[data-label="1.0"],
+      [active-label="2.0"] a.search-filter[data-label="2.0"],
+      [active-label="Blog"] a.search-filter[data-label="Blog"],
+      [active-label="all"] a.search-filter[data-label="all"] {
+        color: #f50057;
+      }
+
       .search-result {
         margin-bottom: 20px;
       }
@@ -37,17 +93,81 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       .search-label[data-label="all"] {
         color: black;
       }
+
+      .pagination {
+        display: flex;
+      }
+
+      .pagination .flex {
+        flex: 1;
+      }
+
+      .pagination a {
+        color: #fff;
+        background: #1e88e5;
+        text-transform: uppercase;
+        text-decoration: none;
+        font-size: 13px;
+        padding: 3px 20px;
+        margin-bottom: 5px;
+        border-radius: 2px;
+        text-align: center;
+        display: inline-block;
+        font-weight: 400;
+      }
+
+      .pagination a:not([href]) {
+        display: none;
+      }
     </style>
 
-    <dom-repeat items="[[items]]">
-      <template>
-        <div class="search-result">
-          <span class="search-label" data-label$="[[item.label]]">[[item.label]]</span>
-          <a href="[[item.link]]">[[item.title]]</a>
-          <p class="snippet">[[item.snippet]]</p>
+    <iron-ajax id="cseSearch" url="https://www.googleapis.com/customsearch/v1" last-response="{{response}}"></iron-ajax>
+
+    <div query$="[[query]]" no-results$=[[!response.items]]>
+      <div class="no-query">
+        <h2>Search</h2>
+        <p>Use the search bar above to search the site.</p>
+      </div>
+
+      <div class="yes-query">
+        <h2>Search results for <span class="search-query">[[query]]</span></h2>
+        <div active-label$="[[activeLabel]]">
+          Filter by:
+          <a href$="[[_getFilterHref(query, '1.0')]]" class="search-filter" data-label="1.0">1.0</a>|
+          <a href$="[[_getFilterHref(query, '2.0')]]" class="search-filter" data-label="2.0">2.0</a>|
+          <a href$="[[_getFilterHref(query, 'Blog')]]" class="search-filter" data-label="Blog">Blog</a>|
+          <a href$="[[_getFilterHref(query, '')]]" class="search-filter" data-label="all">All</a>
         </div>
-      </template>
-    </dom-repeat>
+        <br>
+
+        <div class="no-results">
+          <p>Your search — <span class="search-query small">[[query]]</span> — did not match any documents.</p>
+          <p>Suggestions:</p>
+          <ul>
+            <li>Make sure all words are spelled correctly.</li>
+            <li>Try different keywords.</li>
+            <li>Try more general keywords.</li>
+          </ul>
+        </div>
+        <br>
+
+        <dom-repeat items="[[response.items]]">
+          <template>
+            <div class="search-result">
+              <span class="search-label" data-label$="[[_getLabel(item)]]">[[_getLabel(item)]]</span>
+              <a href="[[item.link]]">[[item.title]]</a>
+              <p class="snippet">[[item.snippet]]</p>
+            </div>
+          </template>
+        </dom-repeat>
+
+        <div class="pagination">
+          <a href$="[[_getPageHref(response.queries.previousPage)]]" class="blue-button">Previous page</a>
+          <div class="flex"></div>
+          <a href$="[[_getPageHref(response.queries.nextPage)]]" class="blue-button">Next page</a>
+        </div>
+      </div>
+    </div>
   </template>
 
   <script>
@@ -56,11 +176,73 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     properties: {
       /**
-       * Search result items.
+       * Query params from app-location - set by pw-shell.
        */
-      items: {
+      searchParams: {
+        type: Object,
+        observer: '_searchParamsChanged'
+      },
+
+      query: {
+        type: String
+      },
+
+      activeLabel: {
+        type: String
+      },
+
+      response: {
         type: Object
       }
+    },
+
+    _searchParamsChanged: function(newParams, oldParams) {
+      // Either the whole query may have changed (because we added or changed
+      // the +more: search parameter, or the start page has changed in the
+      // same query)
+      var oldQ = oldParams ? oldParams.q : null;
+      var oldStart = oldParams ? oldParams.start : null;
+      if (newParams && newParams.q &&
+          (newParams.q !== oldQ || newParams.start !== oldStart)) {
+        var matches = newParams.q.match(/(.*) more:(1\.0|2\.0|Blog)/);
+        if (matches && matches.length > 2) {
+          this.query = matches[1];
+          this.activeLabel = matches[2];
+        } else {
+          this.query = newParams.q;
+          this.activeLabel = 'all';
+        }
+
+        this.$.cseSearch.params = {
+          q: newParams.q,
+          key: 'AIzaSyCMGfdDaSfjqv5zYoS0mTJnOT3e9MURWkU',
+          cx: '012790892085874323134:dqsp1svowso'
+        };
+
+        // Paginated search.
+        if (newParams.start && newParams.start !== 0) {
+          this.$.cseSearch.params.start = newParams.start;
+        }
+
+        // analytics
+        if (window.recordSearch) {
+          window.recordSearch(newParams.q);
+        }
+
+        this.$.cseSearch.generateRequest();
+      }
+    },
+
+    _getLabel: function(item) {
+      return item.labels[0].displayName;
+    },
+
+    _getFilterHref: function(q, label) {
+      return '?q=' + q + (label ? ' more:' + label : '');
+    },
+
+    _getPageHref: function(page) {
+      return page ? '?q=' + page[0].searchTerms + '&start=' + page[0].startIndex : null;
     }
   });
   </script>

--- a/app/elements/pw-shell.html
+++ b/app/elements/pw-shell.html
@@ -143,12 +143,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <app-location route="{{_route}}" path="{{path}}"></app-location>
+    <app-location route="{{_route}}" path="{{path}}" query-params="{{_searchParams}}"></app-location>
     <app-route route="[[_route]]" pattern="/:version/:section" data="{{_routeData}}"></app-route>
-    <app-route route="{{_route}}" pattern="/search/" query-params="{{_searchParams}}"></app-route>
 
     <iron-ajax url="[[path]]" handle-as="document" on-response="_handleResponse" on-error="_handleError" auto></iron-ajax>
-    <iron-ajax id="cseSearch" url="https://www.googleapis.com/customsearch/v1" on-response="_handleSearchResponse"></iron-ajax>
 
     <app-header class="header" reveals snaps shadow>
       <div class="header-toolbar layout horizontal center">
@@ -269,39 +267,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _onSearchInputChange: function() {
-      this.path = '/search/';
-      this._searchParams = {'q':this.$.searchBox.value, 'start':null} ;
+      var url = window.location.origin + '/search/?q=' + this.$.searchBox.value;
+      window.history.pushState({}, '', url);
+      this.fire('location-changed', {}, {node: window});
     },
 
     _doSearch: function() {
-      if (this._searchParams.q) {
-        this.$.cseSearch.params = {
-          q: this._searchParams.q,
-          key: 'AIzaSyCMGfdDaSfjqv5zYoS0mTJnOT3e9MURWkU',
-          cx: '012790892085874323134:dqsp1svowso'
-        };
-
-        // Paginated search.
-        if (this._searchParams.start && this._searchParams.start !== 0) {
-          this.$.cseSearch.params.start = this._searchParams.start;
-        }
-
-        // analytics
-        if (window.recordSearch) {
-          window.recordSearch(this._searchParams.q);
-        }
-
-        this.$.cseSearch.generateRequest();
+      var searchResults = this.querySelector('pw-search-results');
+      if (searchResults) {
+        searchResults.searchParams = this._searchParams;
       }
     },
 
-    _searchParamsChanged: function(newParams, oldParams) {
-      // Either the whole query may have changed (because we added or changed
-      // the +more: search parameter, or the start page has changed in the
-      // same query)
-      if (!!oldParams && (newParams !== oldParams || oldParams.start !== newParams.start)) {
-        this._doSearch();
-      }
+    _searchParamsChanged: function() {
+      this._doSearch();
     },
 
     _computeSection: function(path) {
@@ -369,7 +348,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // If we have any query parameters, that means we are displaying the
       // search results page, and we should kick off a search, if we
       // haven't already
-      if (this.path === '/search/' && this._searchParams.q) {
+      if (this.path === '/search/') {
         this._doSearch();
       }
 
@@ -388,83 +367,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.toggleClass('selected', true, activeLink);
         this.styleLinkPath(activeLink, true);
       }
-    },
-
-    _handleSearchResponse: function(event) {
-      var i;  // the linter which may not be named has issues.
-      var response = event.detail.response;
-
-      // Hide the existing section being displayed.
-      var resultsElement = Polymer.dom(this).querySelector('.search-results');
-      resultsElement.querySelector('section > div:not([hidden])').hidden = true;
-
-      var section;  // The results section that we're going to show.
-      var searchParams = this._searchParams.q;
-
-      // Ugh, so. we use the (undocumented) +more:version
-      // search parameter, which means we need to uhhh remove the +more
-      // keyword by hand if it already exists.
-      var matches = searchParams.match(/(.*) more:(1\.0|2\.0|Blog)/);
-      var activeLabel;
-      if (matches && matches.length > 2) {
-        searchParams = matches[1];
-        activeLabel = matches[2];
-      }
-
-      // Restricted search buttons.
-      var queryPrefix = '?q=' + searchParams;
-      var labels = resultsElement.querySelectorAll('a.search-filter');
-      for (i = 0; i < labels.length; i++) {
-        if (labels[i].dataset.label === 'all') {
-          labels[i].href = queryPrefix;
-          this.toggleClass('active', !activeLabel,  labels[i]);
-        } else {
-          labels[i].href = queryPrefix + '+more:' + labels[i].dataset.label;
-          this.toggleClass('active', labels[i].dataset.label === activeLabel, labels[i]);
-        }
-      }
-
-      if (!response || !response.items) {
-        section = resultsElement.querySelector('.no-results');
-      } else if (response.items) {
-        section = resultsElement.querySelector('.yes-results');
-
-        // Clean up the version bit for easier using.
-        for (var item = 0; item < response.items.length; item++) {
-          response.items[item].label = response.items[item].labels[0].displayName;
-        }
-
-        // Populate the results in the dom-repeat.
-        section.querySelector('#searchResults').items = response.items;
-
-        // Previous and Next buttons.
-        queryPrefix += '&start=';
-
-        var button = section.querySelector('.next-results');
-        if (response.queries.nextPage) {
-          this.toggleClass('button-hidden', false, button);
-          button.href = queryPrefix + response.queries.nextPage[0].startIndex;
-        } else {
-          this.toggleClass('button-hidden', true, button);
-        }
-
-        button = section.querySelector('.previous-results');
-        if (response.queries.previousPage) {
-          this.toggleClass('button-hidden', false, button);
-          button.href = queryPrefix + response.queries.previousPage[0].startIndex;
-        } else {
-          this.toggleClass('button-hidden', true, button);
-        }
-      }
-
-      // There's a bunch of places where we displayed what you searched for.
-      var queryElements = section.querySelectorAll('.search-query');
-      for (i = 0; i < queryElements.length; i++) {
-        queryElements[i].textContent = searchParams;
-      }
-
-      // Flawless victory.
-      section.hidden = false;
     },
 
     styleLinkPath: function(link, opened) {

--- a/app/elements/pw-shell.html
+++ b/app/elements/pw-shell.html
@@ -204,6 +204,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
 
   <script>
+  Polymer.setPassiveTouchGestures(true);
+
   Polymer({
     is: 'pw-shell',
 

--- a/app/sass/_main.scss
+++ b/app/sass/_main.scss
@@ -33,19 +33,15 @@ body {
   font-family: Helvetica, Arial, sans-serif;
   line-height: 24px;
   font-weight: 300;
-
-  /* Set up so the footer always sticks to the bottom of the screen, regardless
-   * of the content size */
-  display: flex;
-  min-height: 100vh;
-  flex-direction: column;
-
-  transition: opacity ease-in 0.2s;
 }
 
 pw-shell {
   display: block;
   margin-top: 64px;
+
+  /* Set up so the footer is always at the bottom of the screen, regardless
+   * of the content size */
+  min-height: 100vh;
 }
 
 /* For nonversioned pages, the server needs to send both v1 and v2 links for

--- a/app/search/index.html
+++ b/app/search/index.html
@@ -17,91 +17,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <pw-shell server-rendered>
     {% include 'templates/site-nav.html' %}
 
-    <!-- Because we want the styles to be loaded when the pw-shell changes its
-      content, they need to be here, and not in the <head> -->
-    <style>
-      .search-results {
-        min-height: 400px;
-      }
-
-      .search-query {
-        color: #1e87ea !important;
-      }
-
-      .search-query.small {
-        color: black;
-        font-weight: bold;
-      }
-
-      a.search-filter {
-        padding: 0 10px;
-        display: inline-block;
-        cursor: pointer;
-      }
-
-      a.search-filter.active {
-        color: #f50057;
-      }
-
-      .results-button-container {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-      }
-
-      .button-hidden {
-        pointer-events: none;
-        visibility: hidden;
-      }
-    </style>
-
-    <div class="search-results">
-      <section class="short">
-        <div class="no-search">
-          <h2>Search</h2>
-          <p>Use the search bar above to search the site.</p>
-        </div>
-
-        <div class="yes-results" hidden>
-          <h2>Search results for <span class="search-query"></span></h2>
-          <div>
-            Filter by:
-            <a class="search-filter" data-label="1.0">1.0</a>|
-            <a class="search-filter" data-label="2.0">2.0</a>|
-            <a class="search-filter" data-label="Blog">Blog</a>|
-            <a class="search-filter" data-label="all">All</a>
-          </div>
-          <br><br>
-
-          <pw-search-results id="searchResults"></pw-search-results>
-
-          <div class="results-button-container">
-            <a href="" class="previous-results blue-button">Previous page</a>
-            <a href="" class="next-results blue-button">Next page</a>
-          </div>
-        </div>
-
-        <div class="no-results" hidden>
-          <h2>Search results for <span class="search-query"></span></h2>
-          <div>
-            Filter by:
-            <a class="search-filter" data-label="1.0">1.0</a>|
-            <a class="search-filter" data-label="2.0">2.0</a>|
-            <a class="search-filter" data-label="Blog">Blog</a>|
-            <a class="search-filter" data-label="all">All</a>
-          </div>
-          <br>
-          <p>Your search — <span class="search-query small"></span> — did not match any documents.</p>
-          <p>Suggestions:</p>
-          <ul>
-            <li>Make sure all words are spelled correctly.</li>
-            <li>Try different keywords.</li>
-            <li>Try more general keywords.</li>
-          </ul>
-        </div>
-      </section>
-    </div>
-
+    <section class="short">
+      <pw-search-results></pw-search-results>
+    </section>
   </pw-shell>
   <pw-footer></pw-footer>
   <script src="/js/app.js"></script>


### PR DESCRIPTION
Building off of #2358, this change moves most of the search functionality to the lazy-loaded `<pw-search-results>` element. This reduces the complexity of `<pw-shell>`.

Staged at https://search-dot-polymer-project.appspot.com/search/?q=css