### PR TITLE
Use `polymer install`, not `bower install`

### DIFF
--- a/app/2.0/start/first-element/intro.md
+++ b/app/2.0/start/first-element/intro.md
@@ -80,9 +80,9 @@ To install Polymer CLI:
 
 To install the element's dependencies and run the demo:
 
-1.  Run `bower install` from the repo directory:
+1.  Run `polymer install` from the repo directory:
 
-        bower install
+        polymer install
 
     This installs the components and dependencies required to use the Polymer library and other web 
 components. 


### PR DESCRIPTION
Installing `polymer-cli` doesn't give you a `bower` in your path, but it does give you `polymer`