### PR TITLE
Change edit-on-github link generation. Fixes #2387.

### DIFF
--- a/server.py
+++ b/server.py
@@ -49,6 +49,9 @@ ARTICLES_FILE = 'blog.yaml'
 AUTHORS_FILE = 'authors.yaml'
 IS_DEV = os.environ.get('SERVER_SOFTWARE', '').startswith('Dev')
 
+# base path for edit-on-github links
+BASE_EDIT_PATH = "https://github.com/Polymer/docs/edit/master/app/%s.md"
+
 def render(out, template, data={}):
   try:
     t = env.get_template(template)
@@ -214,10 +217,13 @@ class Site(http2push.PushHandler):
       return
 
     template_path = path
+    # edit_on_github_path is different for index files.
+    edit_on_github_path = path
     # Root / serves index.html.
     # Folders server the index file (e.g. /docs/index.html -> /docs/).
     if not path or path.endswith('/'):
       template_path += 'index.html'
+      edit_on_github_path += 'index'
     # Remove index.html from URL.
     elif path.endswith('index'):
       # TODO: preserve URL parameters and hash.
@@ -238,6 +244,7 @@ class Site(http2push.PushHandler):
         'path': '/' + path,
         # 1.0 and 2.0 API docs are not editable in GH.
         'edit_on_github': path.find('.0/docs/api/') == -1,
+        'edit_on_github_path': BASE_EDIT_PATH % edit_on_github_path,
         'versioned_paths': self.get_versioned_paths(shortpath),
         # we use this as a macro in cross-references.
         # please don't take it away.

--- a/templates/base-devguide.html
+++ b/templates/base-devguide.html
@@ -49,7 +49,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             {% if edit_on_github %}
               <a class="edit-on-github" target="_blank"
-                  href="https://github.com/Polymer/docs/edit/master/app{{{path}}}.md">
+                  href="{{{edit_on_github_path}}}">
                 Edit on GitHub
               </a>
             {% endif %}


### PR DESCRIPTION
This change centralizes the generation of the edit-on-github link into `server.py` instead of patching it together in the template.

It special cases `index.md` pages—which at the moment is pretty much just the toolbox landing page.

As an additional bonus, it lets pages override the default edit-on-github link by defining a variable, which means we could add edit-on-github links to the API page by adding a line like this to the generated file:

```
{% set edit_on_github_path = "https://github.com/Polymer/polymer/edit/master/lib/mixins/property-accessors.html" %}
```

Whether we want to add those links is another question, but this lets us do that, and I don't think it breaks anything else.

Testing:

- Go to the "App Toolbox" landing page and click "Edit on github".
- If you don't get a 404, it worked.
- Also check other pages, to make sure I didn't break anything.
- Override test: edit dist/2.0/toolbox/index.md and add the following line:

    ```
    {% set edit_on_github_path = "https://github.com/Polymer/polymer/edit/master/lib/mixins/property-accessors.html" %}
    ```

- Run `dev_appserver.py dist` again (_without_ running gulp), click "Edit on Github" on the toolbox landing page, and shazam! you're editing something else.