### PR TITLE
Properly close class mixin documentation

### DIFF
--- a/app/2.0/docs/tools/documentation.md
+++ b/app/2.0/docs/tools/documentation.md
@@ -194,7 +194,7 @@ in Custom element concepts.
  * This mixin lets you travel faster than light speed, almost.
  * @polymer
  * @mixinFunction
- *
+ */
 MyNamespace.WarpSpeedMixin = (superclass) => class extends superclass {
   ...
 }
@@ -208,7 +208,7 @@ add the `@mixinClass` tag immediately before the class declaration. For example:
  * This mixin does something really complicated.
  * @polymer
  * @mixinFunction
- *
+ */
 MyNamespace.ReallyComplicatedMixin = Polymer.dedupingMixin((superclass) =>
 
    // do some other stuff before creating the class...
@@ -235,6 +235,7 @@ An element that applies a mixin should add the `@appliesMixin` tag:
  * @polymer
  * @customElement
  * @appliesMixin MyNamespace.WarpSpeedMixin
+ */
 class MyMixedUpElement extends MyNamespace.WarpSpeedMixin(Polymer.Element) { ... }
 ```
 


### PR DESCRIPTION
The doc comment did not close, resulting in completely commented out code in the blocks:
![image](https://user-images.githubusercontent.com/5948271/35768696-62741db4-0900-11e8-8115-02f6ac1da4fb.png)
