### PR TITLE
Fix notation of observer methods in class

### DIFF
--- a/app/2.0/docs/devguide/observers.md
+++ b/app/2.0/docs/devguide/observers.md
@@ -282,7 +282,7 @@ Example: { .caption }
 
       // For a property or sub-property dependency, the corresponding
       // argument is the new value of the property or sub-property
-      userNameChanged: function(name) {
+      userNameChanged(name) {
         if (name) {
           console.log('new name: ' + name);
         } else {
@@ -519,7 +519,7 @@ static get observers() {
   ]
 }
 
-nameChanged: function(firstName, lastName) {
+nameChanged(firstName, lastName) {
   console.log('new name:', firstName, lastName);
 }
 ```


### PR DESCRIPTION
They were still using the old object notation, but should have been the concise ES6 class method notation.

Fixes #2491