### PR TITLE
fix typos in setter names

### DIFF
--- a/app/2.0/docs/devguide/properties.md
+++ b/app/2.0/docs/devguide/properties.md
@@ -367,8 +367,8 @@ explicit to avoid accidental changes from the host by setting the `readOnly`
 flag to `true` in the `properties` property definition.  In order for the
 element to actually change the value of the property, it must use a private
 generated setter of the convention <code>\_set<var>Property</var>(value)</code>
-where <code><var>Property</var></code> is the property name, with the first character converted to uppercase (if alphabetic). For example, the setter for `oneProperty` is `setOneProperty`, and the setter
-for _privateProperty is `set_privateProperty`.
+where <code><var>Property</var></code> is the property name, with the first character converted to uppercase (if alphabetic). For example, the setter for `oneProperty` is `_setOneProperty`, and the setter
+for _privateProperty is `_set_privateProperty`.
 
 ```
 class XCustom extends Polymer.Element {


### PR DESCRIPTION
I spent an hour debugging this being not able to find the setter. Let's fix this typo.