### PR TITLE
Bump minimum version of iron-doc-viewer to improve anchors.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "app-route": "PolymerElements/app-route#2",
     "iron-ajax": "PolymerElements/iron-ajax#2",
     "iron-collapse": "PolymerElements/iron-collapse#2",
-    "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^3.3.0",
+    "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^3.3.1",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#2",
     "iron-icons": "PolymerElements/iron-icons#2",
     "iron-iconset-svg": "PolymerElements/iron-iconset-svg#2",


### PR DESCRIPTION
This should generate better anchors, and has some fixes to scroll to those anchors more reliably.

Related to https://github.com/Polymer/docs/issues/2541