### PR TITLE
3.0-ify toolbox/index

### DIFF
--- a/app/3.0/toolbox/index.md
+++ b/app/3.0/toolbox/index.md
@@ -3,10 +3,6 @@ subtitle: What's in the box?
 title: Polymer App Toolbox
 ---
 
-<div>
-{% include 'outdated.html' %}
-</div>
-
 Polymer App Toolbox is a collection of components, tools and templates for
 building
 [Progressive Web Apps](https://developers.google.com/web/progressive-web-apps)
@@ -16,23 +12,14 @@ with Polymer. App Toolbox features:
 -   Responsive design using the [app layout components](https://www.webcomponents.org/element/PolymerElements/app-layout).
 -   Modular routing using the
     [`<app-route>`](https://www.webcomponents.org/element/PolymerElements/app-route) elements.
--   Localization with
-    [`<app-localize-behavior>`](https://www.webcomponents.org/element/PolymerElements/app-localize-behavior).
--   Turnkey support for local storage with
-    [app storage elements](https://www.webcomponents.org/element/PolymerElements/app-storage).
 -   Offline caching as a progressive enhancement, using service workers.
 -   Build tooling to support serving your app multiple ways: unbundled for
     delivery over HTTP/2 with server push, and bundled for delivery over HTTP/1.
 
 You can use any one of these components separately, or use them together to build a full-featured
-Progressive web app. Most importantly, each component is _additive_. For a simple app you may only
+progressive web app. Most importantly, each component is _additive_. For a simple app you may only
 need app-layout. As it gets more complicated, you can add routing, offline caching, and a
 high-performance server as required.
-
-**Hybrid compatible.** The Toolbox elements and behaviors are available as hybrid versions, which
-can be used with both Polymer 1 and Polymer 2. Use the `2.0` branch of the elements when
-working with 2.0 Release.
-{.alert .alert-info}
 
 To get a feel for these components in action, you can try out one of the two demo apps:
 
@@ -44,12 +31,11 @@ To get a feel for these components in action, you can try out one of the two dem
     web app demo like Shop, but focusing on publishing. Read about how it's built in
     [Case study: the News app](news-case-study).
 
-
-To get started with the App Toolbox, visit [Build an app with App Toolbox](/2.0/start/toolbox/set-up).
+To get started with the App Toolbox, visit [Build an app with App Toolbox](/{{{polymer_version_dir}}}/start/toolbox/set-up).
 
 Or read on to find out about [Responsive app layout](app-layout).
 
-<a href="/2.0/start/toolbox/set-up" class="blue-button">Build an app
+<a href="/3.0/start/toolbox/set-up" class="blue-button">Build an app
 </a>
 
 <a href="app-layout" class="blue-button">Responsive app layout

--- a/app/3.0/toolbox/index.md
+++ b/app/3.0/toolbox/index.md
@@ -12,11 +12,12 @@ with Polymer. App Toolbox features:
 -   Responsive design using the [app layout components](https://www.webcomponents.org/element/PolymerElements/app-layout).
 -   Modular routing using the
     [`<app-route>`](https://www.webcomponents.org/element/PolymerElements/app-route) elements.
+-   Localization with [`<app-localize-behavior>`](https://www.webcomponents.org/element/PolymerElements/app-localize-behavior).	
+-   Turnkey support for local storage with [app storage elements](https://www.webcomponents.org/element/PolymerElements/app-storage).
 -   Offline caching as a progressive enhancement, using service workers.
 -   Build tooling to support serving your app multiple ways: unbundled for
     delivery over HTTP/2 with server push, and bundled for delivery over HTTP/1.
--   Localization with [`<app-localize-behavior>`](https://www.webcomponents.org/element/PolymerElements/app-localize-behavior).	
--   Turnkey support for local storage with [app storage elements](https://www.webcomponents.org/element/PolymerElements/app-storage).
+
 
 You can use any one of these components separately, or use them together to build a full-featured
 progressive web app. Most importantly, each component is _additive_. For a simple app you may only

--- a/app/3.0/toolbox/index.md
+++ b/app/3.0/toolbox/index.md
@@ -15,6 +15,8 @@ with Polymer. App Toolbox features:
 -   Offline caching as a progressive enhancement, using service workers.
 -   Build tooling to support serving your app multiple ways: unbundled for
     delivery over HTTP/2 with server push, and bundled for delivery over HTTP/1.
+-   Localization with [`<app-localize-behavior>`](https://www.webcomponents.org/element/PolymerElements/app-localize-behavior).	
+-   Turnkey support for local storage with [app storage elements](https://www.webcomponents.org/element/PolymerElements/app-storage).
 
 You can use any one of these components separately, or use them together to build a full-featured
 progressive web app. Most importantly, each component is _additive_. For a simple app you may only


### PR DESCRIPTION
Removed references to app-storage and app-localize-behavior because failing [tests](https://github.com/Polymer/polymer-modulizer/blob/master/docs/polymer-3-element-status.md)
