### PR TITLE
Update browser compat docs.

### DIFF
--- a/app/3.0/docs/browsers.md
+++ b/app/3.0/docs/browsers.md
@@ -4,10 +4,6 @@ title: Browser support overview
 
 <!-- toc -->
 
-<div>
-{% include 'outdated.html' %}
-</div>
-
 Polymer 3.x works in the _latest two versions_ of all major browsers: Safari 9+, IE 11+, and the
 evergreen Chrome, Firefox, and Edge.
 

--- a/app/3.0/docs/browsers.md
+++ b/app/3.0/docs/browsers.md
@@ -4,101 +4,41 @@ title: Browser support overview
 
 <!-- toc -->
 
-Polymer 3.x works in the _latest two versions_ of all major browsers: Safari 9+, IE 11+, and the
+Polymer 3.x works in the _latest two versions_ of all major browsers: Safari 10+, IE 11+, and the
 evergreen Chrome, Firefox, and Edge.
 
 ## Platform features
 
 The Polymer library is a lightweight sugaring layer on top of the [Web Components
 APIs](http://webcomponents.org/articles/why-web-components/). Some features used by Polymer are not
-(yet) supported natively in all browsers. For
-broad web components support, Polymer uses the [polyfills](https://github.com/webcomponents/webcomponentsjs) from
-[webcomponents.org](http://webcomponents.org). They're lightweight, work well, and provide the
-feature support Polymer requires.
+(yet) supported natively in all browsers. 
 
-With the polyfills, Polymer works in these browsers:
+*   For broad web components support, Polymer uses the [polyfills](https://github.com/webcomponents/webcomponentsjs) 
+    from [webcomponents.org](http://webcomponents.org). They're lightweight, work well, and provide the
+    feature support Polymer requires.
 
-<style>
-td:not(.feature-title),th {
-  text-align: center;
-}
-td.native {
-  background-color: green;
-  color: white;
-}
-td.partial {
-  background-color: #2dd42d;
-  color: white;
-}
-td.polyfill {
-  background-color: darkorange;
-  color: black;
-}
-</style>
+*   Polymer uses ES6 language features. For browsers that don't support them, Polymer apps need to be compiled
+    to ES5. 
 
-<table>
-<thead>
-  <tr><th></th><th>Chrome</th><th>Firefox</th><th>IE&nbsp;11+/<br>Edge</th><th>Opera</th><th>Safari 9+</th><th>Chrome
- <br>(Android)</th><th>Safari<br>(iOS&nbsp;9+)</th></tr>
-</thead>
-<tr>
-  <td class="feature-title"><a href="http://www.html5rocks.com/en/tutorials/webcomponents/template/">Template</a></td>
-  <td class="native">Native</td>
-  <td class="native">Native</td>
-  <td class="partial">Partial</td>
-  <td class="native">Native</td>
-  <td class="native">Native</td>
-  <td class="native">Native</td>
-  <td class="native">Native</td>
-</tr>
-<tr>
-  <td class="feature-title"><a href="http://www.html5rocks.com/en/tutorials/webcomponents/customelements/">Custom Elements</a></td>
-  <td class="native">Native</td>
-  <td class="polyfill">Polyfill</td>
-  <td class="polyfill">Polyfill</td>
-  <td class="native">Native</td>
-  <td class="partial">Partial</td>
-  <td class="native">Native</td>
-  <td class="partial">Partial</td>
-</tr>
-<tr>
-  <td class="feature-title"><a href="http://www.html5rocks.com/en/tutorials/webcomponents/shadowdom/">Shadow DOM</a></td>
-  <td class="native">Native</td>
-  <td class="polyfill">Polyfill</td>
-  <td class="polyfill">Polyfill</td>
-  <td class="native">Native</td>
-  <td class="partial">Partial</td>
-  <td class="native">Native</td>
-  <td class="partial">Partial</td>
-</tr>
-</table>
+*   Polymer uses ES6 modules for packaging. These can be bundled out or transformed to AMD modules for browsers that
+    don't support the required features, which include the `import` statement, the dynamic `import()` operator, and
+    the `import.meta` property.
 
-Notes:
+*   Polymer modules also use Node-style module resolution allowing you to import modules by package name. 
+    These specifiers always need to be transformed to paths before being served to browsers.
 
--   Templates are supported in Edge, but not IE.
--   Safari supports custom elements starting in 10.3.
--   Safari supports shadow DOM starting in 10.2, but as of 10.3 there are still some known issues.
--   Older versions of the Android Browser may run into some issues - please file an
-    [issue](https://github.com/polymer/polymer/issues) if you run into a problem on this browser.
-    Chrome for Android is supported.
+The following support matrix summarizes the polyfills and transforms required for each browser.
 
-See the documentation on [polyfills](polyfills) for more information.
+| Browser & version | Compile? | Polyfills? | Transform modules? | Transform specifiers?|
+|---|---|---|---|---|
+| Chrome 66 | No | No | No | Yes|
+| Safari 11.1+ | No | No| No| Yes|
+| Safari 10+|No|Yes|Yes|Yes|
+| Firefox 60|No|Yes|No|Yes|
+| Firefox 59|No|Yes|Yes|Yes|
+| Edge 17|No|Yes|No|Yes|
+| Edge 16|No|Yes|Yes|Yes|
+| IE 11|Yes|Yes|Yes|Yes|
+| Chrome 41 (Google web crawler)|Yes|Yes|Yes|Yes|
 
-## ES6 & modules
-
-Polymer 3.x uses EcmaScript 2015 (commonly known as ES6), and uses ES6 modules as a loading mechanism. The following browsers support all of the ES6 features required by Polymer.
-
--   Chrome or Chromium version 49 or later.
--   Opera 36 or later.
--   Safari or Mobile Safari 10 or later.
--   Edge 16 or later.
--   Firefox 51 or later.
-
-The following browsers support ES6 language features but not ES6 modules.
-
--   Edge 15.15063 or later.
-
-IE 11 doesn't support ES6 language features or modules.
-
-The Polymer tools support transforming ES6 and ES6 modules into forms that run on all of the supported browsers.
-See the documentation on [ES6 & modules](es6) for details.
+See the documentation on [polyfills](polyfills) and [ES6 & modules](es6) for more information.

--- a/app/3.0/docs/browsers.md
+++ b/app/3.0/docs/browsers.md
@@ -8,7 +8,7 @@ title: Browser support overview
 {% include 'outdated.html' %}
 </div>
 
-Polymer 2.x works in the _latest two versions_ of all major browsers: Safari 9+, IE 11+, and the
+Polymer 3.x works in the _latest two versions_ of all major browsers: Safari 9+, IE 11+, and the
 evergreen Chrome, Firefox, and Edge.
 
 ## Platform features
@@ -56,16 +56,6 @@ td.polyfill {
   <td class="native">Native</td>
 </tr>
 <tr>
-  <td class="feature-title"><a href="http://www.html5rocks.com/en/tutorials/webcomponents/imports/">HTML Imports</a></td>
-  <td class="native">Native</td>
-  <td class="polyfill">Polyfill</td>
-  <td class="polyfill">Polyfill</td>
-  <td class="native">Native</td>
-  <td class="polyfill">Polyfill</td>
-  <td class="native">Native</td>
-  <td class="polyfill">Polyfill</td>
-</tr>
-<tr>
   <td class="feature-title"><a href="http://www.html5rocks.com/en/tutorials/webcomponents/customelements/">Custom Elements</a></td>
   <td class="native">Native</td>
   <td class="polyfill">Polyfill</td>
@@ -98,17 +88,21 @@ Notes:
 
 See the documentation on [polyfills](polyfills) for more information.
 
-## ES6
+## ES6 & modules
 
-Polymer 2.x uses EcmaScript 2015 (commonly known as ES6). The following browsers support all of the
-ES6 features required by Polymer.
+Polymer 3.x uses EcmaScript 2015 (commonly known as ES6), and uses ES6 modules as a loading mechanism. The following browsers support all of the ES6 features required by Polymer.
 
 -   Chrome or Chromium version 49 or later.
 -   Opera 36 or later.
 -   Safari or Mobile Safari 10 or later.
--   Edge 15.15063 or later.
+-   Edge 16 or later.
 -   Firefox 51 or later.
 
-For other browsers, you should compile your application to ES5.
+The following browsers support ES6 language features but not ES6 modules.
 
-See the documentation on [compiling ES6 to ES5](es6) for more information.
+-   Edge 15.15063 or later.
+
+IE 11 doesn't support ES6 language features or modules.
+
+The Polymer tools support transforming ES6 and ES6 modules into forms that run on all of the supported browsers.
+See the documentation on [ES6 & modules](es6) for details.

--- a/app/3.0/docs/es6.md
+++ b/app/3.0/docs/es6.md
@@ -67,7 +67,7 @@ in the next section.
 
 ### Module specifiers
 
-The browser only accepts on kind of module specifier in an `import` statement: a URL, which must
+The browser accepts only one kind of module specifier in an `import` statement: a URL, which must
 be either fully-qualified, or a path starting with `/`, `./` or `../`. This works fine for importing 
 application-specific elements and modules:
 
@@ -92,7 +92,7 @@ Many third-party build tools, like WebPack and Rollup also support named modules
 
 ### Dynamic imports
 
-Dynamic imports is a language feature that enables lazy-loading of resources, replacing the functionality 
+Dynamic import is a language feature that enables lazy-loading of resources, replacing the functionality 
 that was previously used for this in Polymer 2.x (`Polymer.importHref`). 
 
 The import operator acts like a function, and returns a `Promise`:
@@ -108,7 +108,7 @@ import('my-view1.js').then((MyView1Module) => {
 The latest versions of Chrome and Safari support dynamic imports. For other browsers, the Polymer build tools can transform
 dynamic imports into AMD modules. The Polymer development server can do this transformation on the fly.
 
-More on dyanmic import, see:
+For more on dynamic import, see:
 
 *   [Dynamic import()](https://developers.google.com/web/updates/2017/11/dynamic-import) on developers.google.com.
 

--- a/app/3.0/docs/es6.md
+++ b/app/3.0/docs/es6.md
@@ -1,46 +1,145 @@
 ---
-title: ES6 and compilation to ES5
+title: ES6 and modules
 ---
 
 <!--toc -->
 
-<div>
-{% include 'outdated.html' %}
-</div>
+Polymer 3.x uses JavaScript language features from the ECMAScript 2015 standard 
+(commonly known as ES6). Polymer 3.x code is distributed as a set of ES6 modules.
 
-Polymer 2.x uses EcmaScript 2015 (commonly known as ES6). The following browsers support all of the
-ES6 features required by Polymer:
+Not all browsers support ES6 modules and other ES6 language features, but the Polymer
+tools support transforming code into supported forms:
 
--   Chrome or Chromium version 49 or later.
--   Opera 36 or later.
--   Safari or Mobile Safari 10 or later.
--   Edge 15.15063 or later.
--   Firefox 51 or later.
+*   ES6 modules can be transformed into AMD modules, which are loaded using a small 
+    JavaScript library, instead of depending on native module support. 
+*   Other ES6 language features can be compiled to use a browser-compatible set of
+    features (usually ES5, which is supported by all modern browsers). 
 
-For other browsers, you should compile your application to ES5.
+To deploy your code, you can either transform it for the lowest common denomniator (ES5,
+transformed to AMD modules), or serve multiple versions of the code to different browsers.
 
 Information on multiple builds and differential serving is available in the
 [documentation on building for production](/{{{polymer_version_dir}}}/toolbox/build-for-production).
 
-## Compiling ES6 to ES5 {#compile}
+## JavaScript (ES6) Modules
 
-Polymer 2.x and native 2.x class-style elements are written using the next generation of the
-JavaScript standard, EcmaScript 2015 (more commonly known as ES6). ES6 is required by the native
-custom element specification. (All browsers that implement native custom elements also support ES6.)
+Polymer 3.x is packaged using JavaScript Modules. JavaScript modules are the first native module
+format implemented by browsers. JavaScript Modules provide _exports_ that can be used by other modules:
+
+```js
+export function fooBar() { ... }
+```
+
+Other modules can import these symbols like this:
+
+```js
+// import a symbol from a module
+import {fooBar} from './my-module.js';
+fooBar('baz');
+
+// import a module for its side-effects (such as registering a custom element)
+import './my-app-element.js';
+```
+Modules can also be loaded from HTML using `<script type="module">`
+
+```js
+<script type="module" src="./main-module.js">
+</script>
+
+<!-- modules can be inline, too -->
+<script type="module">
+import {fooBar} from './my-module.js';
+fooBar('baz');
+</script>
+```
+
+There are a number of online primers on JavaScript modules if you're not familiar with them. 
+
+*   [ECMAScript modules in browsers](https://jakearchibald.com/2017/es-modules-in-browsers/) by Jake Archibald provides a
+    good overview of modules.
+*   [import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) and 
+    [export](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export) pages on MDN 
+    provide a quick reference on module syntax.
+*   [Modules chapter](http://exploringjs.com/es6/ch_modules.html) from Axel Rauschmayer's Exploring ES6.
+
+As an addition to the standard ES6 module syntax, Polymer supports importing modules by name, as described
+in the next section.
+
+### Module specifiers
+
+The browser only accepts on kind of module specifier in an `import` statement: a URL, which must
+be either fully-qualified, or a path starting with `/`, `./` or `../`. This works fine for importing 
+application-specific elements and modules:
+
+```js
+import './my-app-element.js';
+```
+
+However, it's challenging when you're writing a reusable component, and you want to import a peer dependency 
+installed using npm. The path may vary depending on how the components are installed. So Polymer supports 
+the use of Node-style named import specifiers:
+
+```js
+import {PolymerElement} from '@polymer/polymer/polymer-element.js';
+```
+
+Where `@polymer/polymer` is the _name_ of the npm package. (This style of specifier is sometimes called a 
+"bare module specifier".)
+
+These module specifiers need to be transformed to paths before they're served to the browser. The Polymer CLI can transform 
+them at build time, and the Polymer development server can transform them at runtime, so you can test code without a build step.
+Many third-party build tools, like WebPack and Rollup also support named modules.
+
+### Dynamic imports
+
+Dynamic imports is a language feature that enables lazy-loading of resources, replacing the functionality 
+that was previously used for this in Polymer 2.x (`Polymer.importHref`). 
+
+The import operator acts like a function, and returns a `Promise`:
+
+```js
+import('my-view1.js').then((MyView1Module) => {
+  console.log("MyView1 loaded");
+}).catch((reason) => {
+  console.log("MyView1 failed to load", reason);
+});
+```
+
+The latest versions of Chrome and Safari support dynamic imports. For other browsers, the Polymer build tools can transform
+dynamic imports into AMD modules. The Polymer development server can do this transformation on the fly.
+
+More on dyanmic import, see:
+
+*   [Dynamic import()](https://developers.google.com/web/updates/2017/11/dynamic-import) on developers.google.com.
+
+
+## Compiling ES6 and beyond {#compile}
+
+Polymer 3.x elements use features from the ECMAScript 2015 version 
+of the JavaScript standard (commonly known as ES6). ES6 is required by the native
+custom element specification. These features are supported in most but not all common browsers 
+at this point. (All browsers that implement native custom elements also support ES6.)
+
+The following browsers support all of the ES6 features required by Polymer:
+
+-   Chrome or Chromium version 49 or later.
+-   Opera 36 or later.
+-   Safari or Mobile Safari 10 or later.
+-   Edge 16 or later.
+-   Firefox 51 or later.
+
+For other browsers, you should compile your application to ES5. 
 
 The Polymer CLI and `polymer-build` library support compiling ES6 to ES5 at build time. In
 addition, the `polymer serve` and `polymer test` commands compile at runtime when required by the
-browser.
+browser. 
 
-**Device emulation may cause errors**. When using DevTools device emulation in Chrome,
-`polymer serve` will serve compiled code when emulating iOS devices, and uncompiled code when
-emulating Android devices. When switching between devices, the browser may end up with both
-compiled and uncompiled code in its cache, resulting in errors. To avoid this problem, run
-`polymer serve` with the `--compile never` option when testing with device emulation.
-{.alert .alert info}
+While the Polymer library doesn't depend on any features from newer JavaScript standards, 
+ECMAScript 2016 or beyond. However, if you choose to use some of these features, such as 
+async functions, the Polymer tools support compiling these features as well.
 
 For best performance, you should serve ES6 code to browsers that support it, and only serve ES5
-code to browsers that don't support ES6.
+code to browsers that don't support ES6. 
 
 If you need to statically host your code and serve a single version to all browsers, compile
 to ES5.
@@ -49,10 +148,18 @@ When you use the Polymer CLI to compile your app, the CLI automatically compiles
 and injects `custom-elements-es5-adapter.js`, a  lightweight polyfill that lets compiled ES5 work
 on browsers that support native custom elements.
 
+**Device emulation may cause errors**. When using DevTools device emulation in Chrome,
+`polymer serve` will serve compiled code when emulating iOS devices, and uncompiled code when
+emulating Android devices. When switching between devices, the browser may end up with both
+compiled and uncompiled code in its cache, resulting in errors. To avoid this problem, run
+`polymer serve` with the `--compile never` option when testing with device emulation.
+{.alert .alert info}
+
+### Custom builds
+
 If you're putting together a custom build:
 
--   Polymer requires all ES6 features except modules. (If you're using Babel, you can use
-    `babel-preset-es2015` with the `modules` option set to false.)
+-   Polymer requires all ES6 features.
 -   You must compile all your elements, the Polymer library, and any third-party elements you're
     using, but _not_ the polyfills.
 -   If you're serving compiled code to browsers that support native custom elements, inject the
@@ -61,3 +168,6 @@ If you're putting together a custom build:
     to inject the script. If that method doesn't work with your build system, see the
     [webcomponentsjs README](https://github.com/webcomponents/webcomponentsjs#custom-elements-es5-adapterjs)
     for details on using the script.
+
+
+

--- a/app/3.0/docs/polyfills.md
+++ b/app/3.0/docs/polyfills.md
@@ -4,18 +4,14 @@ title: Polyfills
 
 <!--toc -->
 
-<div>
-{% include 'outdated.html' %}
-</div>
-
-Polymer 2.x has been developed alongside and tested with a new suite of v1-spec compatible polyfills
-for custom elements and shadow DOM. You can test Polymer 2.x by using the latest 1.0 version of
-`webcomponentsjs`, which is included as a bower dependency to Polymer 2.x. (`webcomponentsjs`
+Polymer 3.x has been developed alongside and tested with a new suite of v1-spec compatible polyfills
+for custom elements and shadow DOM. You can test Polymer 3.x using the latest 2.0 version of
+`webcomponentsjs`, which is included as a dev dependency to Polymer 3.x. (`webcomponentsjs`
  versions prior to 1.0 support the older, v0 specifications for custom elements and shadow DOM.)
 
 There are two main ways to load the polyfills:
 
-*   `webcomponents-lite.js` includes all of the polyfills necessary to run on any of the supported
+*   `webcomponents-bundle.js` includes all of the polyfills necessary to run on any of the supported
     browsers. Because all browsers receive all polyfills, this results in extra bytes being sent
     to browsers that support one or more feature.
 
@@ -32,7 +28,7 @@ There are a couple of other related polyfill files that you may need:
     on browsers that support native custom elements. This is useful in static serving environments
     where you need to serve a single app version to all browsers. The adapter is discussed in more
     detail in [ES6](es6) and in [Build for production](/{{{polymer_version_dir}}}/toolbox/build-for-production).
-*   `apply-shim.html`. A polyfill for CSS mixins. Unlike the other polyfills, it should be included
+*   `apply-shim.j`. A polyfill for CSS mixins. Unlike the other polyfills, it should be imported
     by any component that defines or applies CSS mixins. For details, see
     [Use custom CSS mixins](/{{{polymer_version_dir}}}/docs/devguide/custom-css-properties#use-custom-css-mixins).
 
@@ -53,10 +49,10 @@ import the polyfills:
   ShadyDOM = { force: true };
   ShadyCSS = { shimcssproperties: true};
 </script>
-<script src="/bower_components/webcomponentsjs/webcomponents-loader.js"></script>
+<script src="./node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 ```
 
-The `webcomponents-lite.js` file also supports forcing the polyfills on by adding query parameters to
+The `webcomponents-bundle.js` file also supports forcing the polyfills on by adding query parameters to
 the app's URL:
 
 `https://www.example.com/my-application/view1?wc-ce&wc-shadydom&wc-shimcssproperties`
@@ -130,10 +126,10 @@ Query parameter:
 
 ## Progress of native browser support
 
-As of April 2017, there has been broad cross-browser agreement around the v1 versions of the [Custom
+As of May 2018 the v1 versions of the [Custom
 Elements](https://w3c.github.io/webcomponents/spec/custom/) and [Shadow
-DOM](https://w3c.github.io/webcomponents/spec/shadow/) APIs, with support in Chrome, Opera, and
-Safari Tech Preview, and implementations underway in other browsers.
+DOM](https://w3c.github.io/webcomponents/spec/shadow/) APIs have been shipped in Chrome, Opera, and
+Safari, and implementations underway in other browsers.
 
 **See** [caniuse.com](http://caniuse.com/) for more information on native browser support for web
 components.
@@ -142,14 +138,14 @@ components.
 Notes:
 
 -   Chrome natively implements both the v0 APIs (used by Polymer 1.x) and the v1 APIs
-    (used by Polymer 2.x).
+    (used by Polymer 2.x & 3.x).
 
--   Safari Tech Preview includes working implementations of Shadow DOM v1 and Custom Elements v1.
+-   Safari includes working implementations of Shadow DOM v1 and Custom Elements v1.
 
 -   Edge has on its backlog to support [Shadow
     DOM v1](https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6263785-shadow-dom-unprefixed)
     and [Custom Elements v1](https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/6261298-custom-elements).
 
--   Firefox currently supports some of the v0 web component APIs behind a flag. Polymer
-    **does not work correctly** with this flag enabled, because of an incompatibility with the web
-    components polyfills.
+-   Firefox currently supports experimental implementations of the custom elements and shadow DOM APIs       
+    behind flags. Polymer **does not work correctly** with the experimental shadow DOM flag enabled, because 
+    of an incompatibility with the web components polyfills.

--- a/app/3.0/docs/polyfills.md
+++ b/app/3.0/docs/polyfills.md
@@ -5,15 +5,19 @@ title: Polyfills
 <!--toc -->
 
 Polymer 3.x has been developed alongside and tested with a new suite of v1-spec compatible polyfills
-for custom elements and shadow DOM. You can test Polymer 3.x using the latest 2.0 version of
-`webcomponentsjs`, which is included as a dev dependency to Polymer 3.x. (`webcomponentsjs`
- versions prior to 1.0 support the older, v0 specifications for custom elements and shadow DOM.)
+for custom elements and shadow DOM. These versions no longer include the HTML imports polyfill,
+and have been developed to work with ES6 modules. You can test Polymer 3.x using the latest 2.0 version of
+`webcomponentsjs` v2.0.0 or later.
+
+(Polyfill versions v1.x.x  include the HTML imports polyfill, and are compatible
+with Polymer 2.x. Versions prior to v1.0 support the older, v0 specifications for custom elements and 
+shadow DOM.)
 
 There are two main ways to load the polyfills:
 
 *   `webcomponents-bundle.js` includes all of the polyfills necessary to run on any of the supported
     browsers. Because all browsers receive all polyfills, this results in extra bytes being sent
-    to browsers that support one or more feature.
+    to browsers that support one or more feature. This replaces the v1.x `webcomponents-lite.js` bundle.
 
 *   `webcomponents-loader.js` performs client-side feature-detection and loads just the required
     polyfills. This requires an extra round-trip to the server, but saves bandwidth for browsers
@@ -28,7 +32,7 @@ There are a couple of other related polyfill files that you may need:
     on browsers that support native custom elements. This is useful in static serving environments
     where you need to serve a single app version to all browsers. The adapter is discussed in more
     detail in [ES6](es6) and in [Build for production](/{{{polymer_version_dir}}}/toolbox/build-for-production).
-*   `apply-shim.j`. A polyfill for CSS mixins. Unlike the other polyfills, it should be imported
+*   `apply-shim.js`. A polyfill for CSS mixins. Unlike the other polyfills, it should be imported
     by any component that defines or applies CSS mixins. For details, see
     [Use custom CSS mixins](/{{{polymer_version_dir}}}/docs/devguide/custom-css-properties#use-custom-css-mixins).
 

--- a/app/3.0/nav.yaml
+++ b/app/3.0/nav.yaml
@@ -121,7 +121,7 @@
   - title: Polyfills
     path: /3.0/docs/polyfills
     indent: True
-  - title: ES6
+  - title: ES6 and modules
     path: /3.0/docs/es6
     indent: True
   - endheader: True


### PR DESCRIPTION
Take 1, updating all this stuff.

Staged here: https://3-0-polyfills-dot-polymer-project.appspot.com/3.0/docs/browsers

Most of the volume here is in my stab at adding info on modules.

Already really good stuff in Dan's README for the polyfills, unsure of whether to pull some of that in here, or to just point to it.

Also, it's still really hard to tell what browser needs what.
I wonder if it'd be better to just have a table like:

Browser & version range   | ES6/ES5 | ES Modules/AMD | Polyfills Req'd | Module name transform

Where we'd have multiple lines for a browser if the values were different.

(And yes, all browsers (currently) require the name=>path transform, but at least it makes it clear that some transform is always required.)

LMK what you think.