### PR TITLE
fix(doc upgrade): missing class name importMeta

### DIFF
--- a/app/3.0/docs/upgrade.md
+++ b/app/3.0/docs/upgrade.md
@@ -195,7 +195,7 @@ Before upgrading an element, make sure that any changes in your repo are committ
     If you use the `importPath` property in you element's template, you must add a static `importMeta` getter:
 
     ```js
-    class extends PolymerElement {
+    class A extends PolymerElement {
       static get importMeta() { return import.meta; }
     }
     ```


### PR DESCRIPTION
This commit adds a class name to the sample of how to upgrade an element
to Polymer 3.0 when it uses `importMeta`.

Fixes #2613