### PR TITLE
superfluous commas in getter examples

### DIFF
--- a/app/3.0/start/first-element/step-3.md
+++ b/app/3.0/start/first-element/step-3.md
@@ -24,7 +24,7 @@ static get properties() {
   return {
     toggleIcon: {
       type: String
-    },
+    }
   };
 }
 ```
@@ -53,7 +53,7 @@ class IconToggle extends PolymerElement {
     return {
       toggleIcon: {
         type: String
-      },
+      }
     };
   }
   constructor() {
@@ -135,7 +135,7 @@ class IconToggle extends PolymerElement {
     return {
       toggleIcon: {
         type: String
-      },
+      }
     };
   }
   constructor() {


### PR DESCRIPTION
superfluous comma in getter with just a single property

the extra comma will generate an error such as:
Uncaught (in promise) SyntaxError: Unexpected token }