### PR TITLE
Mention that es5 adapter comes before WC polyfills

### DIFF
--- a/app/2.0/docs/polyfills.md
+++ b/app/2.0/docs/polyfills.md
@@ -28,6 +28,7 @@ There are a couple of other related polyfill files that you may need:
     on browsers that support native custom elements. This is useful in static serving environments
     where you need to serve a single app version to all browsers. The adapter is discussed in more
     detail in [ES6](es6) and in [Build for production](/{{{polymer_version_dir}}}/toolbox/build-for-production).
+    Important note: the es5 adapter must come _before_ the webcomponents polyfills, if any.
 *   `apply-shim.html`. A polyfill for CSS mixins. Unlike the other polyfills, it should be included
     by any component that defines or applies CSS mixins. For details, see
     [Use custom CSS mixins](/{{{polymer_version_dir}}}/docs/devguide/custom-css-properties#use-custom-css-mixins).


### PR DESCRIPTION
A user ran into a super tricky and difficult to debug issue that ended up being because these were in the wrong order.