### PR TITLE
Fix forcePolyfill code snippet, and add "use click instead of tap" notice.

### DIFF
--- a/app/2.0/docs/polyfills.md
+++ b/app/2.0/docs/polyfills.md
@@ -80,7 +80,7 @@ The following table lists the JavaScript snippets and query parameters for each 
 JavaScript:
 
 ```js
-window.customElements && window.customElements.forcePolyfill = true;
+if (window.customElements) window.customElements.forcePolyfill = true;
 ```
 
 Query parameter:

--- a/app/3.0/docs/devguide/gesture-events.md
+++ b/app/3.0/docs/devguide/gesture-events.md
@@ -9,6 +9,11 @@ interactions. These events fire consistently on both touch and mouse environment
 so we recommend using these events instead of their mouse- or
 touch-specific event counterparts. This provides better interoperability with both touch and mouse devices.
 
+**In general, use the standard `click` event instead of `tap` in mobile browsers.** The `tap`
+event is included in the gesture event mixin for backwards compatibility, but it's no longer
+required in modern mobile browsers.
+{.alert .alert-info}
+
 ## Using gesture events
 
 Add gesture support by importing and using the `GestureEventListeners` mixin:

--- a/app/3.0/docs/polyfills.md
+++ b/app/3.0/docs/polyfills.md
@@ -84,7 +84,7 @@ The following table lists the JavaScript snippets and query parameters for each 
 JavaScript:
 
 ```js
-window.customElements && window.customElements.forcePolyfill = true;
+if (window.customElements) window.customElements.forcePolyfill = true;
 ```
 
 Query parameter:


### PR DESCRIPTION
- Fix `customElements.forcePolyfill` code snippet. The existing snippet had a syntax error (invalid LHS assignment).
- Copy "use click instead of tap" notice from 2.0 to 3.0 docs.